### PR TITLE
feat: implement FreeWork offer detection

### DIFF
--- a/packages/detectors/.eslintrc.cjs
+++ b/packages/detectors/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve("@freelancefinder/config/eslint/base")],
+};

--- a/packages/detectors/package.json
+++ b/packages/detectors/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@freelancefinder/detectors",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc --project tsconfig.json --noEmit"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@freelancefinder/config": "workspace:*",
+    "@freelancefinder/types": "workspace:*",
+    "@types/jsdom": "^21.1.7",
+    "@types/node": "^20.12.7",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/packages/detectors/src/freework/detector.test.ts
+++ b/packages/detectors/src/freework/detector.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import { JSDOM } from "jsdom";
+import {
+  detectFreeWorkOffers,
+  OfferDetectionItem,
+  OfferDetectionOutcome,
+} from "./detector";
+
+const detailUrl = "https://www.free-work.com/fr/tech-it/job/developpeur-fullstack-node-react";
+const listUrl = "https://www.free-work.com/fr/tech-it/job";
+
+const createDom = (html: string, url: string) =>
+  new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { url }).window.document;
+
+const averageConfidence = (offers: OfferDetectionItem[]) =>
+  offers.reduce((acc, offer) => acc + offer.confidence, 0) / (offers.length || 1);
+
+describe("detectFreeWorkOffers", () => {
+  it("returns out_of_scope when url is not a FreeWork page", async () => {
+    const doc = createDom(`<h1>External Offer</h1>`, "https://example.com/job/123");
+
+    const result = await detectFreeWorkOffers(doc, {
+      url: "https://example.com/job/123",
+    });
+
+    expect(result.status).toBe("out_of_scope");
+    expect(result.offers).toHaveLength(0);
+    expect(result.message).toMatch(/hors périmètre FreeWork/i);
+  });
+
+  it("detects a FreeWork detail page with high confidence and rich fields", async () => {
+    const html = `
+      <main>
+        <header>
+          <h1>Développeur Fullstack Node.js / React</h1>
+          <div class="meta">
+            <span class="rate">TJM 600 € / jour</span>
+            <span class="contract">Freelance</span>
+            <span class="location">Paris 75009</span>
+            <span class="remote">3 jours remote</span>
+            <span class="start">Démarrage : 01/06/2024</span>
+            <span class="duration">Durée : 6 mois renouvelable</span>
+            <span class="experience">Expérience : Senior 5 ans</span>
+            <span class="posted">Publié il y a 3 jours</span>
+          </div>
+        </header>
+        <section class="company">
+          <h2>Société</h2>
+          <p>FreeTech Consulting</p>
+        </section>
+        <section class="tags">
+          <span class="tag">Node.js</span>
+          <span class="tag">React</span>
+          <span class="tag">AWS</span>
+          <span class="tag">TypeScript</span>
+        </section>
+        <article class="description">
+          <p>
+            Dans le cadre du renforcement de l'équipe digitale, nous recherchons un développeur fullstack pour intervenir sur la
+            refonte d'une application e-commerce. Vous participerez aux ateliers techniques, mettrez en place les meilleures
+            pratiques DevOps et accompagnerez l'équipe produit.
+          </p>
+          <p>
+            Votre mission consiste à développer des micro-services Node.js, optimiser le front React et contribuer à la migration
+            vers AWS.
+          </p>
+        </article>
+      </main>
+    `;
+
+    const doc = createDom(html, detailUrl);
+
+    const result = await detectFreeWorkOffers(doc, {
+      url: detailUrl,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.pageType).toBe("detail");
+    expect(result.offers).toHaveLength(1);
+
+    const offer = result.offers[0];
+    expect(offer.source).toBe("FreeWork");
+    expect(offer.url).toBe(detailUrl);
+    expect(offer.title).toBe("Développeur Fullstack Node.js / React");
+    expect(offer.contractType).toBe("Freelance");
+    expect(offer.location).toContain("Paris");
+    expect(offer.isRemote).toBe(true);
+    expect(offer.rate?.value).toBe(600);
+    expect(offer.rate?.currency).toBe("EUR");
+    expect(offer.rate?.period).toBe("day");
+    expect(offer.rate?.raw).toContain("600 € / jour");
+    expect(offer.startDate).toContain("01/06/2024");
+    expect(offer.duration).toContain("6 mois");
+    expect(offer.experienceLevel).toMatch(/Senior/i);
+    expect(offer.stack).toEqual(["Node.js", "React", "AWS", "TypeScript"]);
+    expect(offer.description?.length ?? 0).toBeGreaterThan(100);
+    expect(offer.description?.length ?? 0).toBeLessThanOrEqual(1000);
+    expect(offer.postedAt).toMatch(/il y a 3 jours/i);
+    expect(offer.evidence.length).toBeGreaterThanOrEqual(3);
+    expect(offer.confidence).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("detects all visible offers on a FreeWork list page", async () => {
+    const html = `
+      <section class="offers">
+        <article class="offer-card">
+          <a href="/fr/tech-it/job/dev-back-nodejs-1">
+            <h3>Développeur Back-end Node.js</h3>
+            <p class="meta">Lyon • 550 € / jour</p>
+          </a>
+        </article>
+        <article class="offer-card">
+          <a href="/fr/tech-it/job/lead-react-2">
+            <h3>Lead Front React</h3>
+            <p class="meta">Télétravail total • 650 € / jour</p>
+          </a>
+        </article>
+        <article class="offer-card">
+          <a href="/fr/tech-it/job/devops-aws-3">
+            <h3>Ingénieur DevOps AWS</h3>
+            <p class="meta">Nantes</p>
+          </a>
+        </article>
+      </section>
+    `;
+
+    const doc = createDom(html, listUrl);
+
+    const result = await detectFreeWorkOffers(doc, {
+      url: listUrl,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.pageType).toBe("list");
+    expect(result.offers).toHaveLength(3);
+    expect(result.message).toMatch(/Liste détectée : 3 offres/);
+
+    const absoluteUrls = result.offers.map((offer) => offer.url);
+    for (const href of absoluteUrls) {
+      expect(href.startsWith("https://www.free-work.com")).toBe(true);
+    }
+
+    const coverage = result.offers.filter((offer) => offer.location || offer.rate);
+    expect(coverage.length).toBeGreaterThanOrEqual(2);
+
+    expect(averageConfidence(result.offers)).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it("waits briefly for delayed content before concluding", async () => {
+    const doc = createDom(`<div id="app"></div>`, detailUrl);
+
+    const delayedHtml = `
+      <article class="job-detail">
+        <h1>Développeur Cloud</h1>
+        <div class="meta">
+          <span>Tarif : 700 € / jour</span>
+          <span>Remote</span>
+        </div>
+        <article class="description">
+          <p>
+            Mission longue durée visant à accompagner la migration d'un système d'information vers le cloud public. Vous
+            interviendrez sur la mise en place d'une plateforme sécurisée et automatisée.
+          </p>
+          <p>
+            L'équipe attend un profil autonome capable de définir les bonnes pratiques d'infrastructure as code et de piloter
+            l'industrialisation des pipelines CI/CD.
+          </p>
+        </article>
+      </article>
+    `;
+
+    setTimeout(() => {
+      const container = doc.querySelector("#app");
+      if (container) {
+        container.innerHTML = delayedHtml;
+      }
+    }, 30);
+
+    const result = await detectFreeWorkOffers(doc, {
+      url: detailUrl,
+      maxWaitMs: 120,
+      pollIntervalMs: 20,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.offers).toHaveLength(1);
+    expect(result.offers[0].title).toContain("Développeur Cloud");
+  });
+
+  it("returns no_offers with a clear reason when nothing is detectable", async () => {
+    const doc = createDom(`<div class="page">Contenu marketing</div>`, detailUrl);
+
+    const result: OfferDetectionOutcome = await detectFreeWorkOffers(doc, {
+      url: detailUrl,
+      maxWaitMs: 60,
+      pollIntervalMs: 20,
+    });
+
+    expect(result.status).toBe("no_offers");
+    expect(result.offers).toHaveLength(0);
+    expect(result.message).toMatch(/Aucune offre détectable/i);
+    expect(result.diagnostics?.reason).toBeDefined();
+  });
+});

--- a/packages/detectors/src/freework/detector.ts
+++ b/packages/detectors/src/freework/detector.ts
@@ -1,0 +1,897 @@
+import type {
+  DetectionOptions,
+  DetectionPageType,
+  NormalizedRate,
+  OfferDetectionItem,
+  OfferDetectionOutcome,
+  OfferEvidence,
+} from "@freelancefinder/types";
+
+export type {
+  DetectionOptions,
+  DetectionPageType,
+  NormalizedRate,
+  OfferDetectionItem,
+  OfferDetectionOutcome,
+  OfferEvidence,
+} from "@freelancefinder/types";
+
+const FREEWORK_HOST_SUFFIX = "free-work.com";
+const DEFAULT_MAX_WAIT_MS = 180;
+const DEFAULT_POLL_INTERVAL_MS = 40;
+
+const REMOTE_KEYWORDS = [
+  /full\s*remote/i,
+  /remote/i,
+  /télétravail/i,
+  /teletravail/i,
+  /hybride/i,
+  /home\s*office/i,
+];
+
+const CONTRACT_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /freelance/i, label: "Freelance" },
+  { pattern: /cdi/i, label: "CDI" },
+  { pattern: /cdd/i, label: "CDD" },
+  { pattern: /portage/i, label: "Portage" },
+  { pattern: /stage/i, label: "Stage" },
+  { pattern: /alternance/i, label: "Alternance" },
+];
+
+const LOCATION_KEYWORDS = [
+  "paris",
+  "lyon",
+  "marseille",
+  "toulouse",
+  "bordeaux",
+  "nantes",
+  "lille",
+  "rennes",
+  "grenoble",
+  "strasbourg",
+  "montpellier",
+  "nice",
+  "sophia",
+  "niort",
+  "brest",
+  "dijon",
+  "tours",
+  "angers",
+  "rouen",
+  "saint",
+  "télétravail",
+  "remote",
+  "hybride",
+  "france",
+  "idf",
+];
+
+const TECHNOLOGY_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  { label: "Node.js", pattern: /node\.?js/i },
+  { label: "React", pattern: /react/i },
+  { label: "TypeScript", pattern: /typescript|ts\b/i },
+  { label: "JavaScript", pattern: /javascript/i },
+  { label: "AWS", pattern: /\baws\b/i },
+  { label: "Azure", pattern: /azure/i },
+  { label: "GCP", pattern: /\bgoogle cloud|\bgcp\b/i },
+  { label: "Kubernetes", pattern: /kubernetes|k8s/i },
+  { label: "Docker", pattern: /docker/i },
+  { label: "Terraform", pattern: /terraform/i },
+  { label: "Java", pattern: /\bjava\b/i },
+  { label: "Spring", pattern: /spring\b/i },
+  { label: "Python", pattern: /python/i },
+  { label: "Django", pattern: /django/i },
+  { label: "Flask", pattern: /flask/i },
+  { label: "PHP", pattern: /\bphp\b/i },
+  { label: "Symfony", pattern: /symfony/i },
+  { label: "Laravel", pattern: /laravel/i },
+  { label: "Go", pattern: /\bgo\b|golang/i },
+  { label: "Rust", pattern: /rust/i },
+  { label: "C#", pattern: /c#/i },
+  { label: "C++", pattern: /c\+\+/i },
+  { label: "Ruby", pattern: /ruby/i },
+  { label: "Rails", pattern: /rails/i },
+  { label: "Scala", pattern: /scala/i },
+  { label: "Swift", pattern: /swift/i },
+  { label: "Kotlin", pattern: /kotlin/i },
+  { label: "Android", pattern: /android/i },
+  { label: "iOS", pattern: /\bios\b/i },
+  { label: "Angular", pattern: /angular/i },
+  { label: "Vue", pattern: /vue\.js|vuejs|\bvue\b/i },
+  { label: "Svelte", pattern: /svelte/i },
+  { label: "GraphQL", pattern: /graphql/i },
+  { label: "PostgreSQL", pattern: /postgresql|postgres/i },
+  { label: "MySQL", pattern: /mysql/i },
+  { label: "MongoDB", pattern: /mongodb/i },
+  { label: "Redis", pattern: /redis/i },
+  { label: "Kafka", pattern: /kafka/i },
+  { label: "Spark", pattern: /spark/i },
+  { label: "Hadoop", pattern: /hadoop/i },
+  { label: "Elasticsearch", pattern: /elasticsearch|elastic/i },
+];
+
+interface AnalysisResult {
+  pageType: DetectionPageType;
+  offers: OfferDetectionItem[];
+  message?: string;
+  reason?: string;
+}
+
+interface DetailExtractionResult {
+  offer: OfferDetectionItem | null;
+  ready: boolean;
+  reason?: string;
+}
+
+export async function detectFreeWorkOffers(
+  document: Document,
+  options: DetectionOptions,
+): Promise<OfferDetectionOutcome> {
+  const parsedUrl = safeParseUrl(options.url);
+  if (!parsedUrl || !isFreeWorkDomain(parsedUrl)) {
+    return {
+      status: "out_of_scope",
+      message: "Page hors périmètre FreeWork",
+      pageType: "unknown",
+      offers: [],
+    };
+  }
+
+  const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const start = currentTime(options);
+  const deadline = start + maxWaitMs;
+
+  let attempts = 0;
+  let analysis: AnalysisResult = { pageType: "unknown", offers: [], reason: "contenu insuffisant" };
+
+  for (let now = currentTime(options); now <= deadline; now = currentTime(options)) {
+    attempts += 1;
+    analysis = analyseDocument(document, parsedUrl);
+
+    if (analysis.offers.length > 0) {
+      const waitedMs = currentTime(options) - start;
+      return {
+        status: "ok",
+        message: analysis.message ?? buildSuccessMessage(analysis.pageType, analysis.offers.length),
+        pageType: analysis.pageType,
+        offers: analysis.offers,
+        diagnostics: {
+          attempts,
+          waitedMs,
+        },
+      };
+    }
+
+    if (now >= deadline) {
+      break;
+    }
+
+    const remaining = Math.max(0, deadline - now);
+    const waitDuration = Math.min(pollIntervalMs, remaining);
+    if (waitDuration > 0) {
+      await delay(waitDuration);
+    }
+  }
+
+  const finalElapsed = Math.max(0, currentTime(options) - start);
+  const reason = analysis.reason ?? "contenu insuffisant";
+  return {
+    status: "no_offers",
+    message: `Aucune offre détectable (${reason})`,
+    pageType: analysis.pageType,
+    offers: [],
+    diagnostics: {
+      attempts,
+      waitedMs: finalElapsed,
+      reason,
+    },
+  };
+}
+
+function analyseDocument(document: Document, pageUrl: URL): AnalysisResult {
+  const detailExtraction = extractDetailOffer(document, pageUrl);
+  if (detailExtraction.offer && detailExtraction.ready) {
+    return {
+      pageType: "detail",
+      offers: [detailExtraction.offer],
+      message: "Offre détectée (détail)",
+    };
+  }
+
+  const listOffers = extractListOffers(document, pageUrl);
+  if (listOffers.length >= 2) {
+    return {
+      pageType: "list",
+      offers: listOffers,
+      message: `Liste détectée : ${listOffers.length} offres`,
+    };
+  }
+
+  if (detailExtraction.offer) {
+    return {
+      pageType: "detail",
+      offers: [],
+      reason: detailExtraction.reason ?? "informations partielles",
+    };
+  }
+
+  if (listOffers.length === 1) {
+    return {
+      pageType: "list",
+      offers: [],
+      reason: "une seule carte détectée",
+    };
+  }
+
+  const hasHeading = Boolean(findMainHeading(document));
+  return {
+    pageType: "unknown",
+    offers: [],
+    reason: hasHeading ? "structure atypique" : "contenu tardif",
+  };
+}
+
+function extractDetailOffer(document: Document, pageUrl: URL): DetailExtractionResult {
+  const main = document.querySelector("main") ?? document.body;
+  if (!main) {
+    return { offer: null, ready: false, reason: "structure introuvable" };
+  }
+
+  const heading = findMainHeading(main);
+  const title = heading ? normalizeText(heading.textContent) : undefined;
+  if (!title || title.length < 6) {
+    return { offer: null, ready: false, reason: "titre absent" };
+  }
+
+  const metaTexts = collectMetaTexts(main);
+  const rateText = metaTexts.find(looksLikeRate);
+  const rate = rateText ? parseRate(rateText) : undefined;
+
+  const contractType = findContractType(metaTexts);
+  let location = findLocation(metaTexts, { includeRemote: false });
+  const remoteInfo = detectRemote([...metaTexts, location ?? ""]);
+  if (!location && remoteInfo.snippet) {
+    location = remoteInfo.snippet;
+  }
+
+  const startDate = findByLabel(metaTexts, /(d[eé]marrage|d[eé]but|start)/i);
+  const duration = findByLabel(metaTexts, /dur[eé]e/i);
+  const experienceLevel = findExperience(metaTexts);
+  const postedAt = findPostedAt(metaTexts);
+
+  const company = extractCompany(main);
+
+  const tags = collectTags(main);
+  const description = extractDescription(main);
+
+  const stackSet = new Set<string>(tags);
+  detectTechnologiesFromTexts([...metaTexts, description ?? ""], stackSet);
+
+  const stack = Array.from(stackSet);
+  const descriptionSnippet = description ? truncate(description, 900) : undefined;
+
+  const offer: OfferDetectionItem = {
+    source: "FreeWork",
+    url: pageUrl.toString(),
+    title,
+    company,
+    location,
+    isRemote: remoteInfo.isRemote,
+    remotePolicy: remoteInfo.policy,
+    contractType,
+    rate,
+    startDate,
+    duration,
+    experienceLevel,
+    stack,
+    description: descriptionSnippet,
+    postedAt,
+    tags,
+    confidence: 0,
+    evidence: [],
+  };
+
+  const descriptionLength = descriptionSnippet?.length ?? 0;
+  offer.confidence = computeConfidence({
+    hasTitle: Boolean(title),
+    hasRate: Boolean(rate),
+    hasLocationOrRemote: Boolean(location || remoteInfo.isRemote),
+    stackCount: stack.length,
+    descriptionLength,
+    hasContract: Boolean(contractType),
+  });
+
+  populateEvidence(offer, heading, {
+    rateText,
+    location,
+    contractType,
+    startDate,
+    duration,
+    experienceLevel,
+    postedAt,
+    remoteSnippet: remoteInfo.snippet,
+    descriptionSnippet,
+    tags,
+  });
+
+  const essentialSignals = [
+    Boolean(rate),
+    Boolean(location || remoteInfo.isRemote),
+    stack.length >= 2,
+    descriptionLength >= 150,
+  ];
+  const ready = essentialSignals.filter(Boolean).length >= 2 && descriptionLength >= 120;
+  const reason = ready ? undefined : "informations partielles";
+
+  return { offer, ready, reason };
+}
+
+function extractListOffers(document: Document, pageUrl: URL): OfferDetectionItem[] {
+  const anchors = Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href]"));
+  const cards: Array<{ root: Element; anchor: HTMLAnchorElement; title: string }> = [];
+  const seen = new Set<Element>();
+
+  for (const anchor of anchors) {
+    const href = anchor.getAttribute("href");
+    if (!href || !/\bjob\b/i.test(href)) {
+      continue;
+    }
+    const titleElement = anchor.querySelector("h1, h2, h3, h4, h5") ?? anchor;
+    const title = normalizeText(titleElement.textContent);
+    if (!title || title.length < 5 || /postuler/i.test(title)) {
+      continue;
+    }
+
+    const root = anchor.closest("article, li, section, div") ?? anchor;
+    if (seen.has(root)) {
+      continue;
+    }
+    seen.add(root);
+    cards.push({ root, anchor, title });
+  }
+
+  const offers: OfferDetectionItem[] = [];
+  for (const card of cards) {
+    const absoluteUrl = toAbsoluteUrl(card.anchor.getAttribute("href") ?? "", pageUrl);
+    if (!absoluteUrl) {
+      continue;
+    }
+
+    const cardText = normalizeText(card.root.textContent);
+    const segments = splitSegments(cardText);
+    const metaCandidates = collectMetaTexts(card.root);
+    const combinedSegments = uniqueStrings([...segments, ...metaCandidates]);
+
+    const rateText = combinedSegments.find(looksLikeRate);
+    const rate = rateText ? parseRate(rateText) : undefined;
+
+    let location = findLocation(combinedSegments, { includeRemote: true });
+    const remoteInfo = detectRemote(combinedSegments);
+    if (!location && remoteInfo.snippet) {
+      location = remoteInfo.snippet;
+    }
+
+    const stackSet = new Set<string>();
+    detectTechnologiesFromTexts([card.title, ...combinedSegments], stackSet);
+    const tags = collectTags(card.root);
+    for (const tag of tags) {
+      stackSet.add(tag);
+    }
+    const stack = Array.from(stackSet);
+
+    const snippet = buildCardSnippet(card.root, card.title);
+
+    const offer: OfferDetectionItem = {
+      source: "FreeWork",
+      url: absoluteUrl,
+      title: card.title,
+      location,
+      isRemote: remoteInfo.isRemote,
+      remotePolicy: remoteInfo.policy,
+      contractType: findContractType(combinedSegments),
+      rate,
+      stack,
+      description: snippet,
+      tags: uniqueStrings([...tags, ...stack]),
+      confidence: 0,
+      evidence: [],
+    };
+
+    offer.confidence = computeConfidence({
+      hasTitle: true,
+      hasRate: Boolean(rate),
+      hasLocationOrRemote: Boolean(location || remoteInfo.isRemote),
+      stackCount: stack.length,
+      descriptionLength: snippet.length,
+      hasContract: Boolean(offer.contractType),
+    });
+
+    populateEvidence(offer, card.anchor, {
+      rateText,
+      location,
+      contractType: offer.contractType,
+      descriptionSnippet: snippet,
+      remoteSnippet: remoteInfo.snippet,
+      tags: offer.tags,
+    });
+
+    offers.push(offer);
+  }
+
+  return offers;
+}
+
+function populateEvidence(
+  offer: OfferDetectionItem,
+  titleElement: Element | null,
+  parts: {
+    rateText?: string;
+    location?: string;
+    contractType?: string;
+    startDate?: string;
+    duration?: string;
+    experienceLevel?: string;
+    postedAt?: string;
+    remoteSnippet?: string;
+    descriptionSnippet?: string;
+    tags?: string[];
+  },
+) {
+  const evidence: OfferEvidence[] = [];
+  pushEvidence(evidence, "title", offer.title, titleElement ? buildSelector(titleElement) : undefined);
+  if (parts.rateText) {
+    pushEvidence(evidence, "rate", parts.rateText);
+  }
+  if (parts.location) {
+    pushEvidence(evidence, "location", parts.location);
+  }
+  if (offer.rate?.raw && !parts.rateText) {
+    pushEvidence(evidence, "rate", offer.rate.raw);
+  }
+  if (parts.contractType) {
+    pushEvidence(evidence, "contract", parts.contractType);
+  }
+  if (parts.startDate) {
+    pushEvidence(evidence, "startDate", parts.startDate);
+  }
+  if (parts.duration) {
+    pushEvidence(evidence, "duration", parts.duration);
+  }
+  if (parts.experienceLevel) {
+    pushEvidence(evidence, "experience", parts.experienceLevel);
+  }
+  if (parts.postedAt) {
+    pushEvidence(evidence, "postedAt", parts.postedAt);
+  }
+  if (parts.remoteSnippet) {
+    pushEvidence(evidence, "remote", parts.remoteSnippet);
+  }
+  if (parts.descriptionSnippet) {
+    pushEvidence(evidence, "description", truncate(parts.descriptionSnippet, 180));
+  }
+  if (parts.tags && parts.tags.length > 0) {
+    pushEvidence(evidence, "tags", parts.tags.slice(0, 3).join(", "));
+  }
+
+  if (evidence.length < 3 && offer.description) {
+    pushEvidence(evidence, "context", truncate(offer.description, 160));
+  }
+  if (evidence.length < 3 && offer.rate?.raw) {
+    pushEvidence(evidence, "pricing", offer.rate.raw);
+  }
+  if (evidence.length < 3 && offer.location) {
+    pushEvidence(evidence, "geo", offer.location);
+  }
+
+  offer.evidence = evidence;
+}
+
+function findMainHeading(root: ParentNode): Element | null {
+  const heading = root.querySelector("h1") ?? root.querySelector("h2");
+  return heading;
+}
+
+function collectMetaTexts(root: ParentNode): string[] {
+  const selectors = [
+    ".meta",
+    "[class*='meta']",
+    "[class*='info']",
+    "header",
+    "ul",
+    "dl",
+  ];
+  const collected = new Set<string>();
+  for (const selector of selectors) {
+    const elements = root instanceof Document ? root.querySelectorAll(selector) : root.querySelectorAll(selector);
+    for (const element of elements) {
+      for (const child of Array.from(element.querySelectorAll("span, div, li, dt, dd, p"))) {
+        const text = normalizeText(child.textContent);
+        if (!text) continue;
+        if (text.length > 140) continue;
+        collected.add(text);
+      }
+    }
+  }
+
+  if (root instanceof Element) {
+    const immediateSpans = Array.from(root.querySelectorAll("span, li, p"));
+    for (const span of immediateSpans) {
+      const text = normalizeText(span.textContent);
+      if (!text || text.length > 140) continue;
+      collected.add(text);
+    }
+  }
+
+  return Array.from(collected);
+}
+
+function findContractType(metaTexts: string[]): string | undefined {
+  for (const { pattern, label } of CONTRACT_PATTERNS) {
+    if (metaTexts.some((text) => pattern.test(text))) {
+      return label;
+    }
+  }
+  return undefined;
+}
+
+function detectRemote(texts: string[]): { isRemote: boolean; snippet?: string; policy?: string } {
+  for (const text of texts) {
+    if (!text) continue;
+    for (const pattern of REMOTE_KEYWORDS) {
+      if (pattern.test(text)) {
+        return { isRemote: true, snippet: text, policy: normalizeRemotePolicy(text) };
+      }
+    }
+  }
+  return { isRemote: false };
+}
+
+function normalizeRemotePolicy(text: string): string | undefined {
+  const normalized = text.toLowerCase();
+  if (normalized.includes("hybride")) {
+    return "hybrid";
+  }
+  if (normalized.includes("full")) {
+    return "full-remote";
+  }
+  if (normalized.includes("remote") || normalized.includes("télétravail") || normalized.includes("teletravail")) {
+    return "remote";
+  }
+  return undefined;
+}
+
+function findByLabel(metaTexts: string[], label: RegExp): string | undefined {
+  for (const text of metaTexts) {
+    const match = text.match(label);
+    if (match) {
+        const parts = text.split(/[:-]/);
+      if (parts.length > 1) {
+        return normalizeText(parts.slice(1).join(":"));
+      }
+      const after = text.slice(match.index ?? 0 + match[0].length).trim();
+      if (after) {
+        return normalizeText(after);
+      }
+      return text;
+    }
+  }
+  return undefined;
+}
+
+function findExperience(metaTexts: string[]): string | undefined {
+  for (const text of metaTexts) {
+    if (/exp[eé]rience/i.test(text) || /junior/i.test(text) || /senior/i.test(text) || /\b\d+\s*(ans|years)/i.test(text)) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+function findPostedAt(metaTexts: string[]): string | undefined {
+  for (const text of metaTexts) {
+    if (/publi[eé]e?/i.test(text) || /post[eé]e?/i.test(text) || /il y a/i.test(text)) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+function findLocation(metaTexts: string[], options: { includeRemote: boolean }): string | undefined {
+  for (const text of metaTexts) {
+    if (!text) continue;
+    if (!options.includeRemote && REMOTE_KEYWORDS.some((pattern) => pattern.test(text))) {
+      continue;
+    }
+    if (looksLikeRate(text) || /dur[eé]e/i.test(text) || /d[eé]marrage/i.test(text) || /exp[eé]rience/i.test(text)) {
+      continue;
+    }
+    const lower = text.toLowerCase();
+    if (/freelance|cdi|cdd|stage|alternance|portage/.test(lower)) {
+      continue;
+    }
+    if (LOCATION_KEYWORDS.some((keyword) => lower.includes(keyword))) {
+      return text;
+    }
+    if (/\d{5}/.test(text) && /[A-Za-z]/.test(text)) {
+      return text;
+    }
+    const words = lower.split(/[,•-]/).map((part) => part.trim());
+    for (const word of words) {
+      if (word.length >= 3 && /^[a-zéèêàùâûç\s]+$/.test(word) && word.split(" ").length <= 3) {
+        if (!looksLikeRate(word) && !/exp[eé]rience|dur[eé]e|d[eé]marrage/.test(word)) {
+          return text;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function collectTags(root: ParentNode): string[] {
+  const selectors = [".tag", "[class*='tag']", "[class*='skill']", "[class*='stack']", "[data-tag]"];
+  const tags = new Set<string>();
+  for (const selector of selectors) {
+    const elements = root instanceof Document ? root.querySelectorAll(selector) : root.querySelectorAll(selector);
+    for (const element of elements) {
+      const text = normalizeText(element.textContent);
+      if (!text || text.length > 40) continue;
+      const className = element.getAttribute("class")?.toLowerCase() ?? "";
+      const classes = className.split(/\s+/);
+      if (classes.some((cls) => cls === "tags" || cls === "tags-list" || cls === "tag-list")) {
+        continue;
+      }
+      if (element.childElementCount > 0) {
+        const hasTagChild = Array.from(element.children).some((child) => {
+          const childClass = child.getAttribute("class")?.toLowerCase() ?? "";
+          return childClass.includes("tag");
+        });
+        if (hasTagChild) {
+          continue;
+        }
+      }
+      if (/^tag$/i.test(text)) continue;
+      tags.add(text);
+    }
+  }
+  return Array.from(tags);
+}
+
+function extractCompany(root: ParentNode): string | undefined {
+  const headings = Array.from(root.querySelectorAll("h2, h3, strong"));
+  for (const heading of headings) {
+    const text = normalizeText(heading.textContent);
+    if (!text) continue;
+    if (/soci[eé]t[eé]|entreprise|client/i.test(text)) {
+      const nextText = normalizeText(getFollowingText(heading));
+      if (nextText) {
+        return nextText;
+      }
+    }
+  }
+  return undefined;
+}
+
+function getFollowingText(element: Element): string {
+  let node: Element | null = element.nextElementSibling;
+  while (node) {
+    const text = normalizeText(node.textContent);
+    if (text) {
+      return text;
+    }
+    node = node.nextElementSibling;
+  }
+  return "";
+}
+
+function extractDescription(main: Element | Document): string | undefined {
+  const container = main instanceof Document ? main.body : main;
+  if (!container) return undefined;
+
+  const candidates = Array.from(container.querySelectorAll("article, section, div"));
+  let bestText = "";
+  let bestScore = 0;
+  for (const candidate of candidates) {
+    const text = normalizeText(candidate.textContent);
+    if (text.length < 80) continue;
+    const className = candidate.getAttribute("class")?.toLowerCase() ?? "";
+    const dataSection = candidate.getAttribute("data-section")?.toLowerCase() ?? "";
+    let score = text.length;
+    if (/description|mission|detail|content|job-body|presentation/.test(className + dataSection)) {
+      score += 250;
+    }
+    if (candidate.querySelector("p")) {
+      score += 50;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestText = text;
+    }
+  }
+
+  if (!bestText) {
+    const fallback = normalizeText(container.textContent);
+    if (fallback.length >= 120) {
+      bestText = fallback;
+    }
+  }
+
+  if (!bestText) {
+    return undefined;
+  }
+
+  return bestText;
+}
+
+function buildCardSnippet(card: Element, title: string): string {
+  const text = normalizeText(card.textContent);
+  if (!text) return "";
+  const cleaned = text.replace(title, "").trim();
+  const snippet = cleaned.length > 0 ? cleaned : text;
+  return truncate(snippet, 320);
+}
+
+function splitSegments(text: string): string[] {
+  return text
+    .split(/\n|•|\||,|;|\u2022/) // bullet separators
+    .map((segment) => normalizeText(segment))
+    .filter((segment) => Boolean(segment));
+}
+
+function detectTechnologiesFromTexts(texts: string[], stack: Set<string>) {
+  for (const text of texts) {
+    if (!text) continue;
+    for (const tech of TECHNOLOGY_PATTERNS) {
+      if (tech.pattern.test(text)) {
+        stack.add(tech.label);
+      }
+    }
+  }
+}
+
+function computeConfidence(params: {
+  hasTitle: boolean;
+  hasRate: boolean;
+  hasLocationOrRemote: boolean;
+  stackCount: number;
+  descriptionLength: number;
+  hasContract: boolean;
+}): number {
+  let score = 0.25;
+  if (params.hasTitle) score += 0.2;
+  if (params.hasRate) score += 0.15;
+  if (params.hasLocationOrRemote) score += 0.15;
+  if (params.stackCount >= 2) score += 0.1;
+  else if (params.stackCount === 1) score += 0.05;
+  if (params.descriptionLength >= 180) score += 0.1;
+  else if (params.descriptionLength >= 60) score += 0.05;
+  if (params.hasContract) score += 0.05;
+  return Math.min(1, Math.max(0, score));
+}
+
+function pushEvidence(list: OfferEvidence[], label: string, snippet?: string, selector?: string) {
+  if (!snippet) return;
+  const normalized = truncate(snippet, 220);
+  list.push({ label, snippet: normalized, selector });
+}
+
+function buildSelector(element: Element): string {
+  const segments: string[] = [];
+  let current: Element | null = element;
+  while (current && segments.length < 4) {
+    let segment = current.tagName.toLowerCase();
+    if (current.id) {
+      segment += `#${current.id}`;
+      segments.unshift(segment);
+      break;
+    }
+    if (current.classList.length > 0) {
+      segment += `.${Array.from(current.classList).slice(0, 2).join('.')}`;
+    }
+    segments.unshift(segment);
+    current = current.parentElement;
+  }
+  return segments.join(" > ");
+}
+
+function looksLikeRate(text: string): boolean {
+  return /€|eur|\beuros?|\btjm/i.test(text) && /\d/.test(text);
+}
+
+function parseRate(rawText: string): NormalizedRate | undefined {
+  const raw = normalizeText(rawText);
+  if (!raw) return undefined;
+  const valueMatch = raw.match(/(\d+[\d\s,.]*)/);
+  const currency = /€/.test(raw)
+    ? "EUR"
+    : /\bchf\b/i.test(raw)
+      ? "CHF"
+      : /\busd\b|\$/.test(raw)
+        ? "USD"
+        : undefined;
+  const periodMatch = raw.match(/(jour|day|mois|month|an|year|semaine|week)/i);
+  const period = periodMatch
+    ? periodMatch[0].toLowerCase().startsWith("jour") || periodMatch[0].toLowerCase().startsWith("day")
+      ? "day"
+      : periodMatch[0].toLowerCase().startsWith("mois") || periodMatch[0].toLowerCase().startsWith("month")
+        ? "month"
+        : periodMatch[0].toLowerCase().startsWith("semaine") || periodMatch[0].toLowerCase().startsWith("week")
+          ? "week"
+          : "year"
+    : undefined;
+
+  let value: number | undefined;
+  if (valueMatch) {
+    const numeric = valueMatch[1].replace(/[\s,]/g, (char) => (char === "," ? "." : ""));
+    const parsed = Number.parseFloat(numeric);
+    if (!Number.isNaN(parsed)) {
+      value = Number(parsed.toFixed(2));
+    }
+  }
+
+  return {
+    raw,
+    value,
+    currency,
+    period,
+  };
+}
+
+function truncate(value: string, max = 800): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max).trimEnd()}…`;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const set = new Set<string>();
+  for (const value of values) {
+    if (!value) continue;
+    set.add(value);
+  }
+  return Array.from(set);
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return value ? value.replace(/\s+/g, " ").trim() : "";
+}
+
+function buildSuccessMessage(pageType: DetectionPageType, count: number): string {
+  if (pageType === "list") {
+    return `Liste détectée : ${count} offres`;
+  }
+  if (pageType === "detail") {
+    return "Offre détectée (détail)";
+  }
+  return "Détection FreeWork";
+}
+
+function safeParseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch (error) {
+    return null;
+  }
+}
+
+function isFreeWorkDomain(url: URL): boolean {
+  return url.hostname.endsWith(FREEWORK_HOST_SUFFIX);
+}
+
+function toAbsoluteUrl(href: string, base: URL): string | null {
+  try {
+    return new URL(href, base).toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function currentTime(options: DetectionOptions): number {
+  const nowProvider = options.now ?? (() => new Date());
+  return nowProvider().getTime();
+}

--- a/packages/detectors/src/index.ts
+++ b/packages/detectors/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./freework/detector";

--- a/packages/detectors/tsconfig.json
+++ b/packages/detectors/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@freelancefinder/config/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/packages/detectors/vitest.config.ts
+++ b/packages/detectors/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: [],
+    coverage: {
+      reporter: ["text", "lcov"],
+    },
+  },
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,5 +2,11 @@
   "name": "@freelancefinder/types",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./offers": "./src/offers.ts"
+  }
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./offers";

--- a/packages/types/src/offers.ts
+++ b/packages/types/src/offers.ts
@@ -1,0 +1,56 @@
+export type RatePeriod = "day" | "month" | "year" | "hour" | "week";
+
+export interface NormalizedRate {
+  raw: string;
+  value?: number;
+  currency?: string;
+  period?: RatePeriod;
+}
+
+export interface OfferEvidence {
+  label: string;
+  snippet: string;
+  selector?: string;
+}
+
+export interface OfferDetectionItem {
+  source: "FreeWork" | string;
+  url: string;
+  title?: string;
+  company?: string;
+  location?: string;
+  isRemote?: boolean;
+  remotePolicy?: string;
+  contractType?: string;
+  rate?: NormalizedRate;
+  startDate?: string;
+  duration?: string;
+  experienceLevel?: string;
+  stack: string[];
+  description?: string;
+  postedAt?: string;
+  tags: string[];
+  confidence: number;
+  evidence: OfferEvidence[];
+}
+
+export type DetectionPageType = "detail" | "list" | "unknown";
+
+export interface DetectionOptions {
+  url: string;
+  maxWaitMs?: number;
+  pollIntervalMs?: number;
+  now?: () => Date;
+}
+
+export interface OfferDetectionOutcome {
+  status: "ok" | "out_of_scope" | "no_offers" | "content_delayed";
+  message: string;
+  pageType: DetectionPageType;
+  offers: OfferDetectionItem[];
+  diagnostics?: {
+    waitedMs?: number;
+    attempts?: number;
+    reason?: string;
+  };
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@freelancefinder/config/tsconfig/base.json",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 4.20.5
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@20.19.15)
+        version: 1.6.1(@types/node@20.19.15)(jsdom@24.1.3)
 
   apps/web:
     dependencies:
@@ -81,13 +81,87 @@ importers:
         version: 18.3.7(@types/react@18.3.24)
       vitest:
         specifier: ^1.5.0
-        version: 1.6.1(@types/node@20.19.15)
+        version: 1.6.1(@types/node@20.19.15)(jsdom@24.1.3)
 
   packages/config: {}
+
+  packages/detectors:
+    devDependencies:
+      '@freelancefinder/config':
+        specifier: workspace:*
+        version: link:../config
+      '@freelancefinder/types':
+        specifier: workspace:*
+        version: link:../types
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
+      '@types/node':
+        specifier: ^20.12.7
+        version: 20.19.15
+      jsdom:
+        specifier: ^24.0.0
+        version: 24.1.3
+      vitest:
+        specifier: ^1.5.0
+        version: 1.6.1(@types/node@20.19.15)(jsdom@24.1.3)
 
   packages/types: {}
 
 packages:
+
+  /@asamuzakjp/css-color@3.2.0:
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+    dev: true
+
+  /@csstools/color-helpers@5.1.0:
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4):
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+    dev: true
+
+  /@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4):
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+    dev: true
+
+  /@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4):
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+    dev: true
+
+  /@csstools/css-tokenizer@3.0.4:
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+    dev: true
 
   /@esbuild/aix-ppc64@0.21.5:
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -955,6 +1029,14 @@ packages:
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
     dev: true
 
+  /@types/jsdom@21.1.7:
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+    dependencies:
+      '@types/node': 20.19.15
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+    dev: true
+
   /@types/node@20.19.15:
     resolution: {integrity: sha512-W3bqcbLsRdFDVcmAM5l6oLlcl67vjevn8j1FPZ4nx+K5jNoWCh+FC/btxFoBPnvQlrHHDwfjp1kjIEDfwJ0Mog==}
     dependencies:
@@ -978,6 +1060,10 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+    dev: true
+
+  /@types/tough-cookie@4.0.5:
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.9.2):
@@ -1175,6 +1261,11 @@ packages:
     hasBin: true
     dev: true
 
+  /agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+    dev: true
+
   /ajv-formats@2.1.1(ajv@8.17.1):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -1259,6 +1350,10 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
+
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -1315,6 +1410,14 @@ packages:
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
     dev: true
 
   /callsites@3.1.0:
@@ -1375,6 +1478,13 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: true
+
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1407,8 +1517,24 @@ packages:
       which: 2.0.2
     dev: true
 
+  /cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+    dev: true
+
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+    dev: true
+
+  /data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
     dev: true
 
   /debug@4.4.3:
@@ -1423,6 +1549,10 @@ packages:
       ms: 2.1.3
     dev: true
 
+  /decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+    dev: true
+
   /deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -1432,6 +1562,11 @@ packages:
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
+
+  /delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /diff-sequences@29.6.3:
@@ -1453,6 +1588,15 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    dev: true
+
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
@@ -1463,6 +1607,38 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: true
+
+  /entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+    dev: true
+
+  /es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+    dev: true
+
+  /es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
     dev: true
 
   /esbuild@0.21.5:
@@ -1818,6 +1994,17 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
+  /form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    dev: true
+
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1835,8 +2022,36 @@ packages:
     dev: true
     optional: true
 
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    dev: true
+
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
+  /get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+    dev: true
+
+  /get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
     dev: true
 
   /get-stream@8.0.1:
@@ -1907,6 +2122,11 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: false
@@ -1920,9 +2140,62 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-symbols: 1.1.0
+    dev: true
+
+  /hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: true
+
+  /html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      whatwg-encoding: 3.1.1
+    dev: true
+
+  /http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+    dev: true
+
+  /iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
     dev: true
 
   /ignore@5.3.2:
@@ -1987,6 +2260,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    dev: true
+
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2022,6 +2299,42 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
+    dev: true
+
+  /jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.4
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.22
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /json-buffer@3.0.1:
@@ -2128,6 +2441,11 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
+  /math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: true
@@ -2143,6 +2461,18 @@ packages:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+    dev: true
+
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
     dev: true
 
   /mimic-fn@4.0.0:
@@ -2247,6 +2577,10 @@ packages:
       path-key: 4.0.0
     dev: true
 
+  /nwsapi@2.2.22:
+    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
+    dev: true
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2312,6 +2646,12 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
+
+  /parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+    dependencies:
+      entities: 6.0.1
     dev: true
 
   /path-exists@4.0.0:
@@ -2488,9 +2828,19 @@ packages:
       ipaddr.js: 1.9.1
     dev: false
 
+  /psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+    dependencies:
+      punycode: 2.3.1
+    dev: true
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+    dev: true
+
+  /querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
     dev: true
 
   /queue-microtask@1.2.3:
@@ -2536,6 +2886,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
     dev: false
+
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: true
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2603,6 +2957,14 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+    dev: true
+
+  /rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -2619,6 +2981,17 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
     dev: false
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: true
+
+  /saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+    dependencies:
+      xmlchars: 2.2.0
+    dev: true
 
   /scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2787,6 +3160,10 @@ packages:
       has-flag: 4.0.0
     dev: true
 
+  /symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: true
+
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -2848,8 +3225,25 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+    dev: true
+
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+    dependencies:
+      punycode: 2.3.1
+    dev: true
+
+  /tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
     dependencies:
       punycode: 2.3.1
     dev: true
@@ -3022,10 +3416,22 @@ packages:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
     dev: true
 
+  /universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
+    dev: true
+
+  /url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
     dev: true
 
   /vite-node@1.6.1(@types/node@20.19.15):
@@ -3089,7 +3495,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.6.1(@types/node@20.19.15):
+  /vitest@1.6.1(@types/node@20.19.15)(jsdom@24.1.3):
     resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -3124,6 +3530,7 @@ packages:
       chai: 4.5.0
       debug: 4.4.3
       execa: 8.0.1
+      jsdom: 24.1.3
       local-pkg: 0.5.1
       magic-string: 0.30.19
       pathe: 1.1.2
@@ -3146,8 +3553,40 @@ packages:
       - terser
     dev: true
 
+  /w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+    dependencies:
+      xml-name-validator: 5.0.0
+    dev: true
+
   /webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+    dev: true
+
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+
+  /whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
     dev: true
 
   /whatwg-url@7.1.0:
@@ -3200,6 +3639,28 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
+  /xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
 
   /yocto-queue@0.1.0:


### PR DESCRIPTION
## Summary
- add shared detection types for offers
- implement the FreeWork extractor with detail/list heuristics, scoring, and evidence
- cover key detection scenarios with Vitest fixtures

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cb1b4311c0832d9b97fb6318a79078