### PR TITLE
feat: add FreeWork detection extension demo

### DIFF
--- a/apps/extension-demo/README.quickstart.md
+++ b/apps/extension-demo/README.quickstart.md
@@ -1,0 +1,20 @@
+# Quickstart test local
+
+## Installation en 8 étapes maximum
+1. Ouvrez Chrome puis allez sur `chrome://extensions`.
+2. Activez « Mode développeur » (coin supérieur droit).
+3. Cliquez sur « Charger l'extension non empaquetée ».
+4. Sélectionnez le dossier `apps/extension-demo` de ce projet.
+5. Ouvrez une page FreeWork (liste ou détail d'offre) dans un onglet.
+6. Cliquez sur l'icône **FreelanceFinder Demo** dans la barre d'outils.
+7. Pressez « Analyser cette page » et observez le statut + le résumé.
+8. Dépliez « Voir le JSON brut », copiez le JSON si besoin, puis utilisez « Réinitialiser » pour retester.
+
+## Dépannage rapide
+- **Page hors périmètre FreeWork** : vérifiez que l'URL contient `free-work.com` puis relancez l'analyse.
+- **Aucune offre détectable — structure atypique** : la page a changé de structure ; rechargez ou testez une autre offre.
+- **Contenu en cours de chargement, réessayez** : attendez une seconde puis cliquez de nouveau sur « Analyser cette page ».
+
+## Rappels
+- Traitement 100 % local : aucune donnée n'est envoyée hors de votre navigateur.
+- Les boutons « Copier JSON » et « Réinitialiser » permettent de repartir instantanément pour un nouveau test.

--- a/apps/extension-demo/content-script.js
+++ b/apps/extension-demo/content-script.js
@@ -1,0 +1,596 @@
+(() => {
+  const STACK_KEYWORDS = [
+    'javascript',
+    'typescript',
+    'react',
+    'vue',
+    'angular',
+    'node',
+    'java',
+    'python',
+    'aws',
+    'azure',
+    'gcp',
+    'docker',
+    'kubernetes',
+    'terraform',
+    'sql',
+    'devops',
+    'php',
+    'symfony',
+    'laravel',
+    'go',
+    'rust',
+    'scala'
+  ];
+
+  const CONTRACT_LABELS = {
+    freelance: 'Freelance',
+    contractor: 'Freelance',
+    cdd: 'CDD',
+    cdi: 'CDI',
+    permanent: 'CDI',
+    full_time: 'Temps plein',
+    part_time: 'Temps partiel'
+  };
+
+  function isFreeWorkHost(url) {
+    try {
+      const { hostname } = new URL(url);
+      return hostname.endsWith('free-work.com');
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function parseJsonLdScripts() {
+    const scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+    const nodes = [];
+
+    scripts.forEach((script) => {
+      if (!script.textContent) {
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(script.textContent.trim());
+        if (Array.isArray(parsed)) {
+          parsed.forEach((item) => nodes.push(item));
+        } else {
+          nodes.push(parsed);
+        }
+      } catch (error) {
+        // Ignore malformed JSON-LD blocks
+      }
+    });
+
+    const flattened = [];
+
+    nodes.forEach((node) => {
+      if (!node) {
+        return;
+      }
+
+      if (node['@graph'] && Array.isArray(node['@graph'])) {
+        node['@graph'].forEach((child) => flattened.push(child));
+      } else {
+        flattened.push(node);
+      }
+    });
+
+    const jobPostings = [];
+    const itemLists = [];
+
+    flattened.forEach((item) => {
+      const typeValue = item['@type'];
+      const types = Array.isArray(typeValue) ? typeValue.map(String) : [String(typeValue || '')];
+      const normalized = types.map((type) => type.toLowerCase());
+
+      if (normalized.includes('jobposting')) {
+        jobPostings.push(item);
+      }
+
+      if (normalized.includes('itemlist')) {
+        itemLists.push(item);
+      }
+    });
+
+    return { jobPostings, itemLists };
+  }
+
+  function extractText(value) {
+    if (typeof value === 'string') {
+      return value.trim();
+    }
+
+    if (value && typeof value === 'object' && typeof value.name === 'string') {
+      return value.name.trim();
+    }
+
+    return '';
+  }
+
+  function formatRate(baseSalary) {
+    if (!baseSalary) {
+      return '';
+    }
+
+    const value = baseSalary.value || baseSalary;
+
+    if (!value) {
+      return '';
+    }
+
+    let amount = '';
+    let currency = '';
+    let period = '';
+
+  if (typeof value === 'object') {
+    if (value.minValue && value.maxValue) {
+      amount = `${value.minValue} – ${value.maxValue}`;
+    } else if (value.value) {
+      amount = String(value.value);
+    }
+
+    if (value.currency) {
+      currency = value.currency.toUpperCase();
+    }
+
+    if (value.unitText) {
+      period = value.unitText;
+    }
+  } else if (typeof value === 'number') {
+    amount = value.toString();
+  } else if (typeof value === 'string') {
+    amount = value.trim();
+  }
+
+  if (!amount) {
+    return '';
+  }
+
+    const currencySymbol = currency === 'EUR' ? '€' : currency;
+    const unit = period ? mapUnitText(period) : '';
+
+    return `${amount} ${currencySymbol}${unit ? ` / ${unit}` : ''}`.trim();
+  }
+
+  function mapUnitText(unitText) {
+    const normalized = String(unitText || '').toLowerCase();
+
+    if (normalized.includes('hour')) {
+      return 'heure';
+    }
+
+    if (normalized.includes('day')) {
+      return 'jour';
+    }
+
+    if (normalized.includes('month')) {
+      return 'mois';
+    }
+
+    if (normalized.includes('year')) {
+      return 'an';
+    }
+
+    return normalized;
+  }
+
+  function deriveLocation(job) {
+    const locations = [];
+    const jobLocationType = String(job.jobLocationType || '').toLowerCase();
+
+    if (jobLocationType.includes('remote') || jobLocationType.includes('telecommute')) {
+      locations.push('Remote');
+    }
+
+    const jobLocations = Array.isArray(job.jobLocation) ? job.jobLocation : job.jobLocation ? [job.jobLocation] : [];
+
+    jobLocations.forEach((place) => {
+      if (!place) {
+        return;
+      }
+
+      const address = place.address || {};
+      const locality = extractText(address.addressLocality);
+      const region = extractText(address.addressRegion);
+      const country = extractText(address.addressCountry);
+      const composed = [locality, region || country].filter(Boolean).join(', ');
+
+      if (composed) {
+        locations.push(composed);
+      }
+    });
+
+    if (locations.length === 0 && typeof job.jobLocation === 'string') {
+      locations.push(job.jobLocation);
+    }
+
+    if (locations.length === 0) {
+      return '';
+    }
+
+    const unique = Array.from(new Set(locations));
+    return unique.join(' · ');
+  }
+
+  function deriveContract(job) {
+    const raw = Array.isArray(job.employmentType) ? job.employmentType : job.employmentType ? [job.employmentType] : [];
+
+    if (raw.length === 0 && job.contractType) {
+      raw.push(job.contractType);
+    }
+
+    const mapped = raw
+      .map((value) => String(value).toLowerCase())
+      .map((value) => CONTRACT_LABELS[value] || value.replace(/_/g, ' '))
+      .filter(Boolean);
+
+    return Array.from(new Set(mapped)).join(' · ');
+  }
+
+  function extractStack(job) {
+    const collected = [];
+    const containers = [];
+
+    if (Array.isArray(job.skills)) {
+      containers.push(...job.skills);
+    }
+
+    if (Array.isArray(job.requiredSkills)) {
+      containers.push(...job.requiredSkills);
+    }
+
+    if (typeof job.skills === 'string') {
+      containers.push(job.skills);
+    }
+
+    if (typeof job.requiredSkills === 'string') {
+      containers.push(job.requiredSkills);
+    }
+
+    if (typeof job.description === 'string') {
+      containers.push(job.description);
+    }
+
+    if (typeof job.keywords === 'string') {
+      containers.push(job.keywords);
+    }
+
+    const normalizedKeywords = STACK_KEYWORDS.map((keyword) => keyword.toLowerCase());
+
+    containers.forEach((container) => {
+      const text = String(container || '').toLowerCase();
+      normalizedKeywords.forEach((keyword, index) => {
+        if (text.includes(keyword)) {
+          const label = STACK_KEYWORDS[index];
+          collected.push(label);
+        }
+      });
+    });
+
+    const unique = Array.from(new Set(collected));
+    return unique.slice(0, 6);
+  }
+
+  function summarizeJob(job) {
+    const title = extractText(job.title || job.name);
+    const location = deriveLocation(job);
+    const contract = deriveContract(job);
+    const rate = formatRate(job.baseSalary || job.estimatedSalary);
+    const stack = extractStack(job);
+
+    const items = [];
+
+    if (title) {
+      items.push({ label: 'Titre', value: title });
+    }
+
+    if (location) {
+      items.push({ label: 'Lieu / Remote', value: location });
+    }
+
+    if (contract) {
+      items.push({ label: 'Contrat', value: contract });
+    }
+
+    if (rate) {
+      items.push({ label: 'Taux', value: rate });
+    }
+
+    if (stack.length > 0) {
+      items.push({ label: 'Stack', value: stack.join(' · ') });
+    }
+
+    return { items, title, location, contract, rate, stack };
+  }
+
+  function summarizeList(list) {
+    const elements = Array.isArray(list.itemListElement) ? list.itemListElement : [];
+    const offers = [];
+
+    elements.forEach((item) => {
+      if (!item) {
+        return;
+      }
+
+      const offer = item.item || item;
+      const summary = summarizeJob(offer);
+      if (summary.items.length === 0 && offer.name) {
+        summary.items.push({ label: 'Titre', value: extractText(offer.name) });
+      }
+      offers.push({ summary, offer });
+    });
+
+    return offers;
+  }
+
+  function detectFromDom(evidence) {
+    const cards = Array.from(document.querySelectorAll('[data-testid*="job" i], article[class*="job" i], li[class*="job" i]'));
+
+    if (cards.length > 2) {
+      const offers = cards.slice(0, 12).map((card) => {
+        const titleElement = card.querySelector('h2, h3, a');
+        const locationElement = card.querySelector('[class*="location" i], [data-testid*="location" i]');
+        const contractElement = card.querySelector('[class*="contrat" i], [class*="contract" i]');
+        const rateElement = card.querySelector('[class*="tarif" i], [class*="rate" i], [class*="salaire" i]');
+        const stackElements = Array.from(card.querySelectorAll('li, span, a'))
+          .map((element) => element.textContent || '')
+          .filter((text) => text && text.length <= 40);
+
+        const summary = {
+          items: [],
+          title: titleElement && titleElement.textContent ? titleElement.textContent.trim() : '',
+          location: locationElement && locationElement.textContent ? locationElement.textContent.trim() : '',
+          contract: contractElement && contractElement.textContent ? contractElement.textContent.trim() : '',
+          rate: rateElement && rateElement.textContent ? rateElement.textContent.trim() : '',
+          stack: []
+        };
+
+        if (summary.title) {
+          summary.items.push({ label: 'Titre', value: summary.title });
+        }
+
+        if (summary.location) {
+          summary.items.push({ label: 'Lieu / Remote', value: summary.location });
+        }
+
+        if (summary.contract) {
+          summary.items.push({ label: 'Contrat', value: summary.contract });
+        }
+
+        if (summary.rate) {
+          summary.items.push({ label: 'Taux', value: summary.rate });
+        }
+
+        const normalizedStack = [];
+        stackElements.forEach((text) => {
+          const trimmed = text.trim().toLowerCase();
+          STACK_KEYWORDS.forEach((keyword) => {
+            if (trimmed.includes(keyword) && !normalizedStack.includes(keyword)) {
+              normalizedStack.push(keyword);
+            }
+          });
+        });
+
+        if (normalizedStack.length > 0) {
+          summary.stack = normalizedStack;
+          summary.items.push({ label: 'Stack', value: normalizedStack.join(' · ') });
+        }
+
+        return {
+          summary,
+          offer: {
+            title: summary.title,
+            location: summary.location,
+            contract: summary.contract,
+            rate: summary.rate,
+            stack: summary.stack
+          }
+        };
+      });
+
+      evidence.push(`Lecture directe des cartes listées (${offers.length} indices).`);
+      return { kind: 'list', offers };
+    }
+
+    const mainTitle = document.querySelector('h1');
+
+    if (mainTitle && mainTitle.textContent) {
+      const container = mainTitle.closest('article, main, section') || document.body;
+      const locationElement = container.querySelector('[data-testid*="location" i], [class*="location" i]');
+      const contractElement = container.querySelector('[data-testid*="contract" i], [class*="contrat" i]');
+      const rateElement = container.querySelector('[data-testid*="rate" i], [class*="tarif" i], [class*="salaire" i]');
+      const description = container.querySelector('section, div');
+
+      const job = {
+        title: mainTitle.textContent.trim(),
+        jobLocation: locationElement && locationElement.textContent ? locationElement.textContent.trim() : '',
+        employmentType: contractElement && contractElement.textContent ? contractElement.textContent.trim() : '',
+        baseSalary: rateElement && rateElement.textContent ? { value: rateElement.textContent.trim() } : undefined,
+        description: description && description.textContent ? description.textContent.trim().slice(0, 2400) : ''
+      };
+
+      const summary = summarizeJob(job);
+      evidence.push('Résumé construit depuis la structure visible (fallback DOM).');
+      return { kind: 'detail', offers: [{ summary, offer: job }] };
+    }
+
+    return { kind: 'none' };
+  }
+
+  function analyzeDocument() {
+    const evidence = [];
+    const url = window.location.href;
+
+    if (!isFreeWorkHost(url)) {
+      evidence.push('Hôte actuel : ' + url);
+      return {
+        kind: 'out_of_scope',
+        evidence
+      };
+    }
+
+    const { jobPostings, itemLists } = parseJsonLdScripts();
+
+    if (jobPostings.length > 0) {
+      const job = jobPostings[0];
+      const summary = summarizeJob(job);
+      evidence.push('Trouvé JSON-LD JobPosting.');
+
+      const offers = [
+        {
+          summary,
+          offer: job
+        }
+      ];
+
+      return {
+        kind: 'detail',
+        offers,
+        evidence,
+        source: 'json-ld'
+      };
+    }
+
+    if (itemLists.length > 0) {
+      const list = itemLists[0];
+      const offers = summarizeList(list);
+      const filteredOffers = offers.filter((entry) => entry.summary.items.length > 0);
+
+      if (filteredOffers.length > 0) {
+        evidence.push(`Trouvé JSON-LD ItemList avec ${filteredOffers.length} offres.`);
+        return {
+          kind: 'list',
+          offers: filteredOffers,
+          evidence,
+          source: 'json-ld'
+        };
+      }
+    }
+
+    const fallback = detectFromDom(evidence);
+
+    if (fallback.kind !== 'none') {
+      return {
+        kind: fallback.kind,
+        offers: fallback.offers,
+        evidence,
+        source: 'dom'
+      };
+    }
+
+    if (document.readyState !== 'complete') {
+      evidence.push('Le document n\'est pas encore complètement chargé.');
+      return {
+        kind: 'pending',
+        reason: 'contenu tardif',
+        evidence
+      };
+    }
+
+    const loadingIndicators = document.querySelector('[data-testid*="skeleton" i], [class*="skeleton" i], [aria-busy="true"]');
+
+    if (loadingIndicators) {
+      evidence.push('Présence de composants skeleton ou aria-busy.');
+      return {
+        kind: 'pending',
+        reason: 'contenu tardif',
+        evidence
+      };
+    }
+
+    evidence.push('Structure atypique : aucun schéma JSON-LD ni motif d\'offre identifié.');
+    return {
+      kind: 'none',
+      reason: 'structure atypique',
+      evidence
+    };
+  }
+
+  function buildPayload(result) {
+    if (result.kind !== 'detail' && result.kind !== 'list') {
+      return result;
+    }
+
+    const offers = result.offers.map((entry) => {
+      const summary = entry.summary;
+      const offer = entry.offer;
+      return {
+        title: summary.title || extractText(offer.title || offer.name),
+        location: summary.location || deriveLocation(offer),
+        contract: summary.contract || deriveContract(offer),
+        rate: summary.rate || formatRate(offer.baseSalary || offer.estimatedSalary),
+        stack: summary.stack && summary.stack.length > 0 ? summary.stack : extractStack(offer)
+      };
+    });
+
+    const summaryItems = [];
+
+    if (result.kind === 'detail' && offers[0]) {
+      const detail = offers[0];
+      if (detail.title) {
+        summaryItems.push({ label: 'Titre', value: detail.title });
+      }
+      if (detail.location) {
+        summaryItems.push({ label: 'Lieu / Remote', value: detail.location });
+      }
+      if (detail.contract) {
+        summaryItems.push({ label: 'Contrat', value: detail.contract });
+      }
+      if (detail.rate) {
+        summaryItems.push({ label: 'Taux', value: detail.rate });
+      }
+      if (detail.stack && detail.stack.length > 0) {
+        summaryItems.push({ label: 'Stack', value: detail.stack.join(' · ') });
+      }
+    } else {
+      offers.slice(0, 3).forEach((offer, index) => {
+        const parts = [offer.title, offer.location, offer.rate].filter(Boolean);
+        const label = `${index + 1}.`;
+        const value = parts.join(' — ') || 'Offre détectée';
+        summaryItems.push({ label, value });
+      });
+    }
+
+    const rawJson = {
+      url: window.location.href,
+      detectedAt: new Date().toISOString(),
+      pageType: result.kind,
+      offers,
+      evidence: result.evidence,
+      source: result.source || 'dom'
+    };
+
+    return {
+      kind: result.kind,
+      offersCount: offers.length,
+      summary: {
+        items: summaryItems
+      },
+      rawJson,
+      evidence: result.evidence
+    };
+  }
+
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (!message || message.type !== 'FREELANCEFINDER_ANALYZE') {
+      return;
+    }
+
+    try {
+      const analysis = analyzeDocument();
+      const payload = buildPayload(analysis);
+      sendResponse(payload);
+    } catch (error) {
+      sendResponse({
+        kind: 'none',
+        reason: 'erreur inattendue',
+        evidence: ['Une erreur interne a interrompu la détection.']
+      });
+    }
+
+    return true;
+  });
+})();

--- a/apps/extension-demo/manifest.json
+++ b/apps/extension-demo/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "FreelanceFinder Demo",
+  "description": "Démo locale pour repérer des offres FreeWork directement dans le navigateur.",
+  "version": "0.1.0",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "FreelanceFinder Demo"
+  },
+  "permissions": ["tabs", "clipboardWrite"],
+  "host_permissions": ["https://*.free-work.com/*"],
+  "content_scripts": [
+    {
+      "matches": ["https://*.free-work.com/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/apps/extension-demo/popup.css
+++ b/apps/extension-demo/popup.css
@@ -1,0 +1,258 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  min-width: 320px;
+  max-width: 360px;
+  background: linear-gradient(180deg, #ffffff 0%, #f1f5f9 100%);
+}
+
+main {
+  padding: 16px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  background: #e2e8f0;
+  color: #0f172a;
+  padding: 8px 12px;
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+.status-emoji {
+  font-size: 1.2rem;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.primary,
+.secondary,
+.link-button {
+  font: inherit;
+  cursor: pointer;
+  border-radius: 8px;
+  border: none;
+  padding: 10px 14px;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.primary {
+  flex: 1;
+  background: #0f766e;
+  color: #ffffff;
+  font-weight: 600;
+  box-shadow: 0 2px 6px rgba(15, 118, 110, 0.25);
+}
+
+.primary:focus-visible,
+.secondary:focus-visible,
+.link-button:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.primary:disabled {
+  background: #a7f3d0;
+  color: #064e3b;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.secondary {
+  background: #e0f2fe;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.secondary:disabled {
+  background: #cbd5f5;
+  color: #475569;
+  cursor: not-allowed;
+}
+
+.link-button {
+  background: none;
+  color: #2563eb;
+  padding: 4px 6px;
+  font-weight: 600;
+}
+
+.link-button:disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.result {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.section-title {
+  margin: 0 0 8px 0;
+  font-size: 1.05rem;
+}
+
+.summary {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.summary li {
+  background: #f8fafc;
+  border-radius: 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.summary li strong {
+  display: block;
+  color: #0f172a;
+}
+
+.json-panel {
+  margin-top: 12px;
+}
+
+.json-panel summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.json-output {
+  max-height: 160px;
+  overflow: auto;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 10px;
+  border-radius: 8px;
+  font-family: "Fira Code", "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.json-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.copy-feedback {
+  font-size: 12px;
+  color: #0f766e;
+  min-height: 16px;
+}
+
+.evidence {
+  margin-top: 12px;
+}
+
+.evidence-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  color: #1e293b;
+}
+
+.footer-hint {
+  margin-top: 16px;
+  font-size: 12px;
+  color: #475569;
+}
+
+.privacy {
+  margin: 0;
+}
+
+.tour-dialog {
+  border: none;
+  border-radius: 12px;
+  padding: 0;
+  width: 280px;
+  max-width: 90vw;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.25);
+}
+
+.tour-content {
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.tour-step h3 {
+  margin: 0 0 4px 0;
+}
+
+.tour-step p {
+  margin: 0;
+}
+
+.tour-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color: #e2e8f0;
+    background-color: #0f172a;
+  }
+
+  body {
+    background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  }
+
+  .status {
+    background: rgba(148, 163, 184, 0.2);
+    color: #e2e8f0;
+  }
+
+  .result {
+    background: rgba(15, 23, 42, 0.85);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+  }
+
+  .summary li {
+    background: rgba(30, 41, 59, 0.8);
+    color: #e2e8f0;
+  }
+
+  .secondary {
+    background: rgba(148, 163, 184, 0.2);
+    color: #e2e8f0;
+  }
+
+  .json-output {
+    background: #020617;
+  }
+}

--- a/apps/extension-demo/popup.html
+++ b/apps/extension-demo/popup.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FreelanceFinder Demo</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main>
+      <header class="header">
+        <div id="status" class="status" role="status" aria-live="polite">
+          <span class="status-emoji" aria-hidden="true">🟡</span>
+          <span id="status-text">Préparez-vous à analyser une page FreeWork.</span>
+        </div>
+        <button id="open-tour" class="link-button" type="button">Tutoriel express</button>
+      </header>
+
+      <section class="actions">
+        <button id="analyze" class="primary" type="button">Analyser cette page</button>
+        <button id="reset" class="secondary" type="button" disabled>Réinitialiser</button>
+      </section>
+
+      <section id="result" class="result" aria-live="polite" hidden>
+        <h2 class="section-title">Résumé</h2>
+        <ul id="summary" class="summary" aria-label="Synthèse des offres"></ul>
+
+        <details id="json-panel" class="json-panel">
+          <summary>Voir le JSON brut</summary>
+          <pre id="json-output" class="json-output" tabindex="0"></pre>
+          <div class="json-actions">
+            <button id="copy" class="secondary" type="button" disabled>Copier JSON</button>
+            <span id="copy-feedback" class="copy-feedback" role="status" aria-live="polite"></span>
+          </div>
+        </details>
+
+        <div class="evidence">
+          <button id="toggle-evidence" class="link-button" type="button" disabled>
+            Voir les indices
+          </button>
+          <ul id="evidence-list" class="evidence-list" hidden aria-label="Indices utilisés pour la détection"></ul>
+        </div>
+      </section>
+
+      <section class="footer-hint">
+        <p class="privacy">🔒 Traitement local uniquement. Aucune donnée n'est envoyée.</p>
+      </section>
+    </main>
+
+    <dialog id="tour" class="tour-dialog" aria-labelledby="tour-title">
+      <form method="dialog" class="tour-content">
+        <h2 id="tour-title">Mode démo</h2>
+        <div class="tour-step" data-step="0">
+          <h3>1. Installer</h3>
+          <p>Ouvrez les extensions Chrome, activez le mode développeur puis cliquez sur « Charger l'extension non empaquetée ».</p>
+        </div>
+        <div class="tour-step" data-step="1" hidden>
+          <h3>2. Aller sur FreeWork</h3>
+          <p>Visitez une page liste ou détail sur <strong>free-work.com</strong>.</p>
+        </div>
+        <div class="tour-step" data-step="2" hidden>
+          <h3>3. Analyser</h3>
+          <p>Cliquez sur l'icône FreelanceFinder puis sur « Analyser cette page » pour voir le résultat.</p>
+        </div>
+        <div class="tour-actions">
+          <button id="tour-prev" class="secondary" type="button">Précédent</button>
+          <button id="tour-next" class="primary" type="button">Suivant</button>
+          <button id="tour-close" class="link-button" value="close">Fermer</button>
+        </div>
+      </form>
+    </dialog>
+
+    <script src="popup.js" type="module"></script>
+  </body>
+</html>

--- a/apps/extension-demo/popup.js
+++ b/apps/extension-demo/popup.js
@@ -1,0 +1,351 @@
+const statusContainer = document.getElementById('status');
+const statusEmoji = statusContainer.querySelector('.status-emoji');
+const statusText = document.getElementById('status-text');
+const analyzeButton = document.getElementById('analyze');
+const resetButton = document.getElementById('reset');
+const copyButton = document.getElementById('copy');
+const copyFeedback = document.getElementById('copy-feedback');
+const resultSection = document.getElementById('result');
+const summaryList = document.getElementById('summary');
+const jsonOutput = document.getElementById('json-output');
+const jsonPanel = document.getElementById('json-panel');
+const evidenceToggle = document.getElementById('toggle-evidence');
+const evidenceList = document.getElementById('evidence-list');
+const openTourButton = document.getElementById('open-tour');
+const tourDialog = document.getElementById('tour');
+const tourSteps = Array.from(tourDialog.querySelectorAll('.tour-step'));
+const tourPrev = document.getElementById('tour-prev');
+const tourNext = document.getElementById('tour-next');
+const tourClose = document.getElementById('tour-close');
+
+let activeTabId = null;
+let currentResult = null;
+let retryTimeout = null;
+let isAnalyzing = false;
+let tourIndex = 0;
+let isFreeWorkTab = false;
+
+function setStatus(emoji, text) {
+  statusEmoji.textContent = emoji;
+  statusText.textContent = text;
+}
+
+function disableAnalysis() {
+  analyzeButton.disabled = true;
+}
+
+function enableAnalysis() {
+  analyzeButton.disabled = !isFreeWorkTab;
+}
+
+function resetUiState() {
+  currentResult = null;
+  resultSection.hidden = true;
+  summaryList.innerHTML = '';
+  jsonOutput.textContent = '';
+  jsonPanel.open = false;
+  copyButton.disabled = true;
+  evidenceToggle.disabled = true;
+  evidenceToggle.setAttribute('aria-expanded', 'false');
+  evidenceList.hidden = true;
+  evidenceList.innerHTML = '';
+  copyFeedback.textContent = '';
+  resetButton.disabled = true;
+  if (activeTabId !== null) {
+    chrome.action.setBadgeText({ tabId: activeTabId, text: '' });
+  }
+}
+
+async function getActiveTab() {
+  const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  if (tabs && tabs.length > 0) {
+    return tabs[0];
+  }
+  return null;
+}
+
+function isFreeWorkUrl(url) {
+  try {
+    const { hostname } = new URL(url);
+    return hostname.endsWith('free-work.com');
+  } catch (error) {
+    return false;
+  }
+}
+
+function renderSummary(summary) {
+  summaryList.innerHTML = '';
+  if (!summary || !Array.isArray(summary.items)) {
+    return;
+  }
+
+  summary.items.forEach((item) => {
+    const listItem = document.createElement('li');
+    const strong = document.createElement('strong');
+    strong.textContent = item.label;
+    listItem.appendChild(strong);
+    const textNode = document.createElement('span');
+    textNode.textContent = item.value;
+    listItem.appendChild(textNode);
+    summaryList.appendChild(listItem);
+  });
+}
+
+function renderEvidence(evidence) {
+  evidenceList.innerHTML = '';
+  if (!Array.isArray(evidence) || evidence.length === 0) {
+    evidenceToggle.disabled = true;
+    evidenceList.hidden = true;
+    return;
+  }
+
+  evidenceToggle.disabled = false;
+  evidence.forEach((entry) => {
+    const item = document.createElement('li');
+    item.textContent = entry;
+    evidenceList.appendChild(item);
+  });
+}
+
+function formatStatus(result) {
+  if (!result) {
+    return { emoji: '🟡', text: 'Prêt à analyser.' };
+  }
+
+  if (result.kind === 'detail') {
+    const count = result.offersCount || 1;
+    return { emoji: '✅', text: `Détail détecté (${count} offre)` };
+  }
+
+  if (result.kind === 'list') {
+    const count = result.offersCount || 0;
+    return { emoji: '✅', text: `Liste détectée : ${count} offre${count > 1 ? 's' : ''}` };
+  }
+
+  if (result.kind === 'out_of_scope') {
+    return { emoji: '⛔', text: 'Page hors périmètre FreeWork' };
+  }
+
+  if (result.kind === 'pending') {
+    return { emoji: '⏳', text: 'Contenu en cours de chargement, réessayez.' };
+  }
+
+  if (result.kind === 'none') {
+    const reason = result.reason ? ` — ${capitalizeFirst(result.reason)}` : '';
+    return { emoji: '⚠️', text: `Aucune offre détectable${reason}` };
+  }
+
+  return { emoji: '⚠️', text: 'Aucune offre détectable.' };
+}
+
+function capitalizeFirst(text) {
+  if (!text) {
+    return '';
+  }
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function showResult(result) {
+  currentResult = result;
+  resultSection.hidden = false;
+  renderSummary(result.summary);
+  renderEvidence(result.evidence);
+  jsonOutput.textContent = JSON.stringify(result.rawJson, null, 2);
+  copyButton.disabled = false;
+  resetButton.disabled = false;
+  evidenceToggle.setAttribute('aria-expanded', 'false');
+  evidenceList.hidden = true;
+
+  const badgeText = result.offersCount && result.offersCount > 0 ? String(result.offersCount) : '';
+  if (activeTabId !== null) {
+    chrome.action.setBadgeBackgroundColor({ tabId: activeTabId, color: '#0f766e' });
+    chrome.action.setBadgeText({ tabId: activeTabId, text: badgeText });
+  }
+}
+
+async function requestAnalysis(attempt = 1) {
+  if (activeTabId === null) {
+    return;
+  }
+
+  try {
+    const response = await chrome.tabs.sendMessage(activeTabId, { type: 'FREELANCEFINDER_ANALYZE' });
+
+    if (!response) {
+      throw new Error('no_response');
+    }
+
+    if (response.kind === 'pending' && attempt < 3) {
+      const statusInfo = formatStatus(response);
+      setStatus(statusInfo.emoji, statusInfo.text);
+      retryTimeout = setTimeout(() => {
+        requestAnalysis(attempt + 1);
+      }, 1200);
+      return;
+    }
+
+    finalizeAnalysis(response);
+  } catch (error) {
+    const statusInfo = { emoji: '⚠️', text: "Aucune offre détectable — contenu inaccessible." };
+    setStatus(statusInfo.emoji, statusInfo.text);
+    enableAnalysis();
+    isAnalyzing = false;
+  }
+}
+
+function finalizeAnalysis(result) {
+  const statusInfo = formatStatus(result);
+  setStatus(statusInfo.emoji, statusInfo.text);
+
+  if (result.kind === 'detail' || result.kind === 'list') {
+    showResult(result);
+  } else {
+    resetButton.disabled = false;
+    resultSection.hidden = true;
+    if (activeTabId !== null) {
+      chrome.action.setBadgeText({ tabId: activeTabId, text: '' });
+    }
+  }
+
+  enableAnalysis();
+  isAnalyzing = false;
+}
+
+function handleAnalyze() {
+  if (isAnalyzing) {
+    return;
+  }
+
+  if (retryTimeout) {
+    clearTimeout(retryTimeout);
+    retryTimeout = null;
+  }
+
+  isAnalyzing = true;
+  setStatus('🔍', 'Analyse en cours…');
+  enableResetDuringAnalysis();
+  disableAnalysis();
+  requestAnalysis();
+}
+
+function enableResetDuringAnalysis() {
+  resetButton.disabled = false;
+}
+
+function handleReset() {
+  if (retryTimeout) {
+    clearTimeout(retryTimeout);
+    retryTimeout = null;
+  }
+  resetUiState();
+  if (isFreeWorkTab) {
+    setStatus('🟡', 'Prêt à analyser une page FreeWork.');
+  } else {
+    setStatus('⛔', 'Page hors périmètre FreeWork');
+  }
+  enableAnalysis();
+  isAnalyzing = false;
+}
+
+async function init() {
+  const tab = await getActiveTab();
+
+  if (!tab) {
+    setStatus('⚠️', 'Onglet actif introuvable.');
+    disableAnalysis();
+    return;
+  }
+
+  activeTabId = tab.id;
+  isFreeWorkTab = isFreeWorkUrl(tab.url || '');
+
+  if (!isFreeWorkTab) {
+    setStatus('⛔', 'Page hors périmètre FreeWork');
+    disableAnalysis();
+    resetButton.disabled = false;
+    return;
+  }
+
+  setStatus('🟡', 'Prêt à analyser cette page FreeWork.');
+  enableAnalysis();
+}
+
+function handleCopy() {
+  if (!currentResult) {
+    return;
+  }
+
+  const jsonString = JSON.stringify(currentResult.rawJson, null, 2);
+  navigator.clipboard
+    .writeText(jsonString)
+    .then(() => {
+      copyFeedback.textContent = 'JSON copié dans le presse-papier.';
+      setTimeout(() => {
+        copyFeedback.textContent = '';
+      }, 2000);
+    })
+    .catch(() => {
+      copyFeedback.textContent = 'Impossible de copier automatiquement.';
+    });
+}
+
+function toggleEvidence() {
+  const isHidden = evidenceList.hidden;
+  if (isHidden) {
+    evidenceList.hidden = false;
+    evidenceToggle.textContent = 'Masquer les indices';
+    evidenceToggle.setAttribute('aria-expanded', 'true');
+  } else {
+    evidenceList.hidden = true;
+    evidenceToggle.textContent = 'Voir les indices';
+    evidenceToggle.setAttribute('aria-expanded', 'false');
+  }
+}
+
+function openTour() {
+  tourIndex = 0;
+  syncTour();
+  if (typeof tourDialog.showModal === 'function') {
+    tourDialog.showModal();
+  }
+}
+
+function syncTour() {
+  tourSteps.forEach((step, index) => {
+    step.hidden = index !== tourIndex;
+  });
+  tourPrev.disabled = tourIndex === 0;
+  tourNext.textContent = tourIndex === tourSteps.length - 1 ? 'Terminer' : 'Suivant';
+}
+
+function nextTourStep() {
+  if (tourIndex < tourSteps.length - 1) {
+    tourIndex += 1;
+    syncTour();
+    return;
+  }
+  tourDialog.close();
+}
+
+function previousTourStep() {
+  if (tourIndex === 0) {
+    return;
+  }
+  tourIndex -= 1;
+  syncTour();
+}
+
+openTourButton.addEventListener('click', openTour);
+analyzeButton.addEventListener('click', handleAnalyze);
+resetButton.addEventListener('click', handleReset);
+copyButton.addEventListener('click', handleCopy);
+evidenceToggle.addEventListener('click', toggleEvidence);
+tourPrev.addEventListener('click', previousTourStep);
+tourNext.addEventListener('click', nextTourStep);
+tourClose.addEventListener('click', () => tourDialog.close());
+tourDialog.addEventListener('cancel', () => tourDialog.close());
+
+document.addEventListener('DOMContentLoaded', () => {
+  init();
+});
+


### PR DESCRIPTION
## Summary
- add a Manifest V3 demo extension that analyses FreeWork pages locally and updates the action badge with offer counts
- build a guided popup UI featuring status messaging, human summary, collapsible JSON with copy/reset controls, and an evidence log
- document an eight-step Quickstart README with troubleshooting tips for rapid local installation

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cdc350d160832dae10ffba4452204a