### PR TITLE
refactor: modularize detectors and extension demo

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -1,0 +1,119 @@
+# Refactoring FreelanceFinder — plan directeur
+
+## Audit initial
+
+### Packages / détection
+- `packages/detectors/src/freework/detector.ts` concentre toute la logique métier (368+ lignes) :
+  - mélange orchestration (boucle d'attente), parsing DOM, normalisation, scoring, constitution des preuves.
+  - définitions répétées (regex remote, mots-clés lieux, pile techno) en dur et non réutilisables.
+  - aucune séparation claire entre extraction (lecture DOM), normalisation (taux, remote, texte) et utilitaires.
+- Typage : `OfferDetectionItem` défini dans `packages/types` mais enrichi/complété localement, pas de contrat « JobOffer » unique partagé avec l'extension.
+
+### Extension (content-script + popup)
+- `apps/extension-demo/content-script.js` duplique l'intégralité des heuristiques : listes de technos, mapping contrats, parsing taux/dates/remote.
+  - mélange JSON-LD, fallback DOM et formatage UI dans un seul IIFE.
+  - aucune mutualisation avec le paquet TypeScript → divergence à terme assurée.
+- `apps/extension-demo/popup.js` (≈250 lignes) combine état, orchestration Chrome API, rendu, accessibilité.
+  - logique de statut / badge, rendu JSON, gestion du tutoriel imbriqués sans découpage.
+
+### Points de couplage / dette
+- Duplication massive des regex heuristiques (remote, taux, stack) entre le paquet TS et l'extension.
+- Absence de modules utilitaires partagés (DOM helpers, normalisation texte, URL absolue).
+- Pas de gestion centralisée de l'état transitoire (polling deadline, diagnostics) : tout est codé inline.
+- Contrat de données divergent entre détecteur et UI (summary adhoc côté popup).
+
+## Plan de refactor
+
+1. **Contrat unifié**
+   - Introduire `JobOffer` et `OfferDetectionResult` dans `packages/types/src/offers.ts` comme source de vérité.
+   - Fournir alias rétrocompatibles (`OfferDetectionItem`) pour ne pas casser les imports existants.
+
+2. **Modules partagés (packages/detectors)**
+   - Créer dossiers :
+     - `types/` → glue avec `@freelancefinder/types` (contrats, gardes d'entrée/sortie).
+     - `utils/` → helpers DOM (`queryText`, `buildSelector`, `toAbsoluteUrl`), URL, temps (`delay`, `now`), collections.
+     - `normalize/` → `text.ts`, `rate.ts`, `remote.ts`, `location.ts` (centralisation regex/keywords).
+     - `parsing/` → découpage par responsabilité : `meta.ts` (headings, méta), `technologies.ts`, `description.ts`.
+     - `state/` → gestion du polling (deadline/diagnostics), accumulateur de preuves.
+   - Extraire toutes les fonctions actuelles de `detector.ts` dans ces modules et ne laisser que l'orchestration (≤120 lignes).
+
+3. **Détecteur FreeWork**
+   - Réécrire `freework/detector.ts` pour utiliser les nouveaux modules :
+     - validation URL → `utils/url`.
+     - boucle d'attente → `state/poller`.
+     - extraction detail/list → modules `parsing` + `normalize`.
+     - constitution de `OfferEvidence` via `state/evidence-builder`.
+   - Assurer invariants (guards sur DOM absent) + messages identiques.
+
+4. **Extension — mutualisation heuristiques**
+   - Migrer le content-script vers un module ES (`src/content-script.ts`), transpilation via `tsc` (outDir `dist`).
+   - Réutiliser les helpers de `@freelancefinder/detectors` (import direct → bundlé dans le build) pour analyser la page et produire le payload pour la popup.
+   - Fournir fallback DOM léger côté content-script pour formatter le résultat (résumé) sans heuristiques dupliquées.
+   - Mettre à jour `manifest.json` et `popup.html` pour pointer vers `dist/*.js` générés.
+
+5. **Extension — popup**
+   - Déplacer la logique dans `src/popup/` :
+     - `state.ts` (état courant + transitions autorisées).
+     - `render.ts` (rendu status, summary, evidence).
+     - `actions.ts` (handlers Chrome, copy, analyse, tutoriel).
+     - `main.ts` orchestrant initialisation.
+   - Conserver API utilisateur (mêmes boutons, textes, statuts) + factoriser helpers (`formatStatus`, `toggleSection`).
+
+6. **Tests & validations**
+   - Adapter tests Vitest pour les nouveaux modules (tests unitaires sur normalize/rate/location, evidence builder).
+   - Couvrir content-script par tests unitaires (si possible via vitest + jsdom) sur formatage résumé.
+   - Exécuter `pnpm lint`, `pnpm typecheck`, `pnpm test` (detectors + extension build) à chaque étape.
+
+7. **Documentation & migration**
+   - Documenter dans ce fichier les nouveaux points d'entrée (où importer `JobOffer`, comment lancer le build extension).
+   - Lister les imports à remplacer (ancien `./freework/detector` → `@freelancefinder/detectors/freework`).
+
+## Étapes d'exécution
+
+1. Mettre en place le contrat `JobOffer` + alias.
+2. Créer modules `normalize/`, `utils/`, `parsing/`, `state/` et migrer progressivement les fonctions du détecteur (avec tests après chaque sous-ensemble).
+3. Réécrire `detectFreeWorkOffers` pour orchestrer les modules extraits.
+4. Installer toolchain TS (tsconfig) pour l'extension, déplacer scripts en `src/`, réutiliser les helpers mutualisés.
+5. Refactor popup en modules + orchestrateur `main`.
+6. Ajouter/adapter tests unitaires côté detectors et extension.
+7. Finaliser documentation (section diff avant/après dans ce fichier).
+
+## Cartographie après extraction
+
+### `packages/detectors`
+- `types/` : réexport du contrat unique `JobOffer`, utilisé par le détecteur et l'extension.
+- `normalize/` : normalise texte, TJM, remote et lieux (tests unitaires dans `rate.test.ts`, `location.test.ts`, `remote.test.ts`).
+- `parsing/` : heuristiques DOM spécialisées (méta-infos, tags, description, techno).
+- `state/` : outils transverses (poller, calcul de confiance, construction des preuves).
+- `utils/` : helpers purs (URL, temps, collections, sélecteurs CSS).
+- `freework/` : orienteur `detector.ts` + extracteurs `detail.ts` / `list.ts` reposant sur les modules partagés.
+
+### `apps/extension-demo`
+- `src/lib/` : mappers communs (`result-mapper`, `offer-summary`, `evidence-format`, nouveau `detector-loader`).
+- `src/popup/` : séparation stricte entre DOM (`dom.ts`), rendu (`render.ts`), statut (`status.ts`), état (`state.ts`) et actions (`actions.ts`).
+- `src/content-script.ts` : mince orchestration qui délègue l'analyse au détecteur mutualisé.
+- `tsup.config.ts` : bundling unique des points d'entrée `content-script`, `popup` et `detector`.
+
+## Duplications résolues
+
+- Heuristiques de détection (TJM, remote, stack) : déplacées de l'ancien `content-script.js` et de l'ancien `detector.ts` vers `packages/detectors/src/normalize` & `parsing`.
+- Conversion d'URL relatives → absolues : centralisée dans `utils/url.ts` et réutilisée côté liste.
+- Construction des preuves et calcul de confiance : désormais dans `state/evidence.ts` et `state/confidence.ts` (partagés détail/liste).
+- Gestion du cache d'import dynamique : isolée dans `src/lib/detector-loader.ts` (remplace la duplication de promesse dans le content-script).
+
+## Diff synthétique (avant → après)
+
+| Domaine | Avant | Après |
+| --- | --- | --- |
+| Détection FreeWork | `detector.ts` monolithique (orchestration + parsing) | `detector.ts` (<120 lignes) + `detail.ts`/`list.ts` découpés avec helpers partagés |
+| Normalisation | Regex et conversions dispersées | Modules dédiés (`normalize/`) testés individuellement |
+| Extension content-script | Heuristiques dupliquées, import statique | Content-script fin, import dynamique résilient via `lib/detector-loader` |
+| Popup | Fichier unique ~250 lignes | Modules spécialisés (`dom`, `render`, `status`, `state`, `actions`) |
+| Tests | Couverture limitée au détecteur global | Tests unitaires sur helpers (`normalize/*.test.ts`, `result-mapper.test.ts`, `detector-loader.test.ts`) |
+
+## Migration interne
+
+- Importer les contrats depuis `@freelancefinder/types` (`JobOffer`, `OfferDetectionOutcome`) au lieu de définir des variantes locales.
+- Pour charger le détecteur côté navigateur, utiliser `loadDetector()` de `@freelancefinder/extension-demo/src/lib/detector-loader` et gérer l'éventuel rejet (déjà encapsulé dans le content-script).
+- Pour ajouter une nouvelle heuristique FreeWork, contribuer aux modules partagés (`normalize/`, `parsing/`) puis consommer via `detail.ts` ou `list.ts`.
+- Construire l'extension avec `pnpm --filter @freelancefinder/extension-demo build` (copie automatique de `dist/*.js` vers la racine du package).

--- a/apps/extension-demo/.eslintrc.cjs
+++ b/apps/extension-demo/.eslintrc.cjs
@@ -1,0 +1,10 @@
+const baseConfig = require("@freelancefinder/config/eslint/base");
+
+module.exports = {
+  ...baseConfig,
+  env: {
+    ...baseConfig.env,
+    browser: true,
+  },
+  ignorePatterns: ["dist/**", "node_modules/**"],
+};

--- a/apps/extension-demo/content-script.js
+++ b/apps/extension-demo/content-script.js
@@ -1,596 +1,162 @@
-(() => {
-  const STACK_KEYWORDS = [
-    'javascript',
-    'typescript',
-    'react',
-    'vue',
-    'angular',
-    'node',
-    'java',
-    'python',
-    'aws',
-    'azure',
-    'gcp',
-    'docker',
-    'kubernetes',
-    'terraform',
-    'sql',
-    'devops',
-    'php',
-    'symfony',
-    'laravel',
-    'go',
-    'rust',
-    'scala'
-  ];
-
-  const CONTRACT_LABELS = {
-    freelance: 'Freelance',
-    contractor: 'Freelance',
-    cdd: 'CDD',
-    cdi: 'CDI',
-    permanent: 'CDI',
-    full_time: 'Temps plein',
-    part_time: 'Temps partiel'
-  };
-
-  function isFreeWorkHost(url) {
-    try {
-      const { hostname } = new URL(url);
-      return hostname.endsWith('free-work.com');
-    } catch (error) {
-      return false;
+// src/lib/offer-summary.ts
+var LIST_PREVIEW_LIMIT = 3;
+var STACK_PREVIEW_LIMIT = 6;
+function buildSummary(pageType, offers) {
+  if (pageType === "detail" && offers[0]) {
+    return { items: buildDetailSummary(offers[0]) };
+  }
+  return { items: buildListSummary(offers.slice(0, LIST_PREVIEW_LIMIT)) };
+}
+function buildDetailSummary(offer) {
+  const items = [];
+  if (offer.title) {
+    items.push({ label: "Titre", value: offer.title });
+  }
+  const location = formatLocation(offer);
+  if (location) {
+    items.push({ label: "Lieu / Remote", value: location });
+  }
+  if (offer.contractType) {
+    items.push({ label: "Contrat", value: offer.contractType });
+  }
+  if (offer.rate?.raw) {
+    items.push({ label: "Taux", value: offer.rate.raw });
+  }
+  if (offer.stack.length > 0) {
+    items.push({ label: "Stack", value: offer.stack.slice(0, STACK_PREVIEW_LIMIT).join(" \xB7 ") });
+  }
+  return items;
+}
+function buildListSummary(offers) {
+  return offers.map((offer, index) => {
+    const parts = [offer.title, formatLocation(offer), offer.rate?.raw].filter(Boolean);
+    const value = parts.join(" \u2014 ") || "Offre d\xE9tect\xE9e";
+    return { label: `${index + 1}.`, value };
+  });
+}
+function formatLocation(offer) {
+  const parts = [];
+  if (offer.location) {
+    parts.push(offer.location);
+  }
+  if (offer.isRemote) {
+    const policy = offer.remotePolicy ?? "Remote";
+    if (!parts.some((part) => part.toLowerCase().includes("remote"))) {
+      parts.push(policy);
     }
   }
+  if (parts.length === 0) {
+    return void 0;
+  }
+  return parts.join(" \u2014 ");
+}
 
-  function parseJsonLdScripts() {
-    const scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
-    const nodes = [];
-
-    scripts.forEach((script) => {
-      if (!script.textContent) {
-        return;
-      }
-
-      try {
-        const parsed = JSON.parse(script.textContent.trim());
-        if (Array.isArray(parsed)) {
-          parsed.forEach((item) => nodes.push(item));
-        } else {
-          nodes.push(parsed);
-        }
-      } catch (error) {
-        // Ignore malformed JSON-LD blocks
-      }
+// src/lib/evidence-format.ts
+function flattenEvidence(offers) {
+  const collected = [];
+  offers.forEach((offer, index) => {
+    const prefix = offers.length > 1 ? `${index + 1}. ` : "";
+    offer.evidence.forEach((entry) => {
+      collected.push(`${prefix}${formatLabel(entry.label)} \u2014 ${entry.snippet}`);
     });
-
-    const flattened = [];
-
-    nodes.forEach((node) => {
-      if (!node) {
-        return;
-      }
-
-      if (node['@graph'] && Array.isArray(node['@graph'])) {
-        node['@graph'].forEach((child) => flattened.push(child));
-      } else {
-        flattened.push(node);
-      }
-    });
-
-    const jobPostings = [];
-    const itemLists = [];
-
-    flattened.forEach((item) => {
-      const typeValue = item['@type'];
-      const types = Array.isArray(typeValue) ? typeValue.map(String) : [String(typeValue || '')];
-      const normalized = types.map((type) => type.toLowerCase());
-
-      if (normalized.includes('jobposting')) {
-        jobPostings.push(item);
-      }
-
-      if (normalized.includes('itemlist')) {
-        itemLists.push(item);
-      }
-    });
-
-    return { jobPostings, itemLists };
-  }
-
-  function extractText(value) {
-    if (typeof value === 'string') {
-      return value.trim();
-    }
-
-    if (value && typeof value === 'object' && typeof value.name === 'string') {
-      return value.name.trim();
-    }
-
-    return '';
-  }
-
-  function formatRate(baseSalary) {
-    if (!baseSalary) {
-      return '';
-    }
-
-    const value = baseSalary.value || baseSalary;
-
-    if (!value) {
-      return '';
-    }
-
-    let amount = '';
-    let currency = '';
-    let period = '';
-
-  if (typeof value === 'object') {
-    if (value.minValue && value.maxValue) {
-      amount = `${value.minValue} – ${value.maxValue}`;
-    } else if (value.value) {
-      amount = String(value.value);
-    }
-
-    if (value.currency) {
-      currency = value.currency.toUpperCase();
-    }
-
-    if (value.unitText) {
-      period = value.unitText;
-    }
-  } else if (typeof value === 'number') {
-    amount = value.toString();
-  } else if (typeof value === 'string') {
-    amount = value.trim();
-  }
-
-  if (!amount) {
-    return '';
-  }
-
-    const currencySymbol = currency === 'EUR' ? '€' : currency;
-    const unit = period ? mapUnitText(period) : '';
-
-    return `${amount} ${currencySymbol}${unit ? ` / ${unit}` : ''}`.trim();
-  }
-
-  function mapUnitText(unitText) {
-    const normalized = String(unitText || '').toLowerCase();
-
-    if (normalized.includes('hour')) {
-      return 'heure';
-    }
-
-    if (normalized.includes('day')) {
-      return 'jour';
-    }
-
-    if (normalized.includes('month')) {
-      return 'mois';
-    }
-
-    if (normalized.includes('year')) {
-      return 'an';
-    }
-
-    return normalized;
-  }
-
-  function deriveLocation(job) {
-    const locations = [];
-    const jobLocationType = String(job.jobLocationType || '').toLowerCase();
-
-    if (jobLocationType.includes('remote') || jobLocationType.includes('telecommute')) {
-      locations.push('Remote');
-    }
-
-    const jobLocations = Array.isArray(job.jobLocation) ? job.jobLocation : job.jobLocation ? [job.jobLocation] : [];
-
-    jobLocations.forEach((place) => {
-      if (!place) {
-        return;
-      }
-
-      const address = place.address || {};
-      const locality = extractText(address.addressLocality);
-      const region = extractText(address.addressRegion);
-      const country = extractText(address.addressCountry);
-      const composed = [locality, region || country].filter(Boolean).join(', ');
-
-      if (composed) {
-        locations.push(composed);
-      }
-    });
-
-    if (locations.length === 0 && typeof job.jobLocation === 'string') {
-      locations.push(job.jobLocation);
-    }
-
-    if (locations.length === 0) {
-      return '';
-    }
-
-    const unique = Array.from(new Set(locations));
-    return unique.join(' · ');
-  }
-
-  function deriveContract(job) {
-    const raw = Array.isArray(job.employmentType) ? job.employmentType : job.employmentType ? [job.employmentType] : [];
-
-    if (raw.length === 0 && job.contractType) {
-      raw.push(job.contractType);
-    }
-
-    const mapped = raw
-      .map((value) => String(value).toLowerCase())
-      .map((value) => CONTRACT_LABELS[value] || value.replace(/_/g, ' '))
-      .filter(Boolean);
-
-    return Array.from(new Set(mapped)).join(' · ');
-  }
-
-  function extractStack(job) {
-    const collected = [];
-    const containers = [];
-
-    if (Array.isArray(job.skills)) {
-      containers.push(...job.skills);
-    }
-
-    if (Array.isArray(job.requiredSkills)) {
-      containers.push(...job.requiredSkills);
-    }
-
-    if (typeof job.skills === 'string') {
-      containers.push(job.skills);
-    }
-
-    if (typeof job.requiredSkills === 'string') {
-      containers.push(job.requiredSkills);
-    }
-
-    if (typeof job.description === 'string') {
-      containers.push(job.description);
-    }
-
-    if (typeof job.keywords === 'string') {
-      containers.push(job.keywords);
-    }
-
-    const normalizedKeywords = STACK_KEYWORDS.map((keyword) => keyword.toLowerCase());
-
-    containers.forEach((container) => {
-      const text = String(container || '').toLowerCase();
-      normalizedKeywords.forEach((keyword, index) => {
-        if (text.includes(keyword)) {
-          const label = STACK_KEYWORDS[index];
-          collected.push(label);
-        }
-      });
-    });
-
-    const unique = Array.from(new Set(collected));
-    return unique.slice(0, 6);
-  }
-
-  function summarizeJob(job) {
-    const title = extractText(job.title || job.name);
-    const location = deriveLocation(job);
-    const contract = deriveContract(job);
-    const rate = formatRate(job.baseSalary || job.estimatedSalary);
-    const stack = extractStack(job);
-
-    const items = [];
-
-    if (title) {
-      items.push({ label: 'Titre', value: title });
-    }
-
-    if (location) {
-      items.push({ label: 'Lieu / Remote', value: location });
-    }
-
-    if (contract) {
-      items.push({ label: 'Contrat', value: contract });
-    }
-
-    if (rate) {
-      items.push({ label: 'Taux', value: rate });
-    }
-
-    if (stack.length > 0) {
-      items.push({ label: 'Stack', value: stack.join(' · ') });
-    }
-
-    return { items, title, location, contract, rate, stack };
-  }
-
-  function summarizeList(list) {
-    const elements = Array.isArray(list.itemListElement) ? list.itemListElement : [];
-    const offers = [];
-
-    elements.forEach((item) => {
-      if (!item) {
-        return;
-      }
-
-      const offer = item.item || item;
-      const summary = summarizeJob(offer);
-      if (summary.items.length === 0 && offer.name) {
-        summary.items.push({ label: 'Titre', value: extractText(offer.name) });
-      }
-      offers.push({ summary, offer });
-    });
-
-    return offers;
-  }
-
-  function detectFromDom(evidence) {
-    const cards = Array.from(document.querySelectorAll('[data-testid*="job" i], article[class*="job" i], li[class*="job" i]'));
-
-    if (cards.length > 2) {
-      const offers = cards.slice(0, 12).map((card) => {
-        const titleElement = card.querySelector('h2, h3, a');
-        const locationElement = card.querySelector('[class*="location" i], [data-testid*="location" i]');
-        const contractElement = card.querySelector('[class*="contrat" i], [class*="contract" i]');
-        const rateElement = card.querySelector('[class*="tarif" i], [class*="rate" i], [class*="salaire" i]');
-        const stackElements = Array.from(card.querySelectorAll('li, span, a'))
-          .map((element) => element.textContent || '')
-          .filter((text) => text && text.length <= 40);
-
-        const summary = {
-          items: [],
-          title: titleElement && titleElement.textContent ? titleElement.textContent.trim() : '',
-          location: locationElement && locationElement.textContent ? locationElement.textContent.trim() : '',
-          contract: contractElement && contractElement.textContent ? contractElement.textContent.trim() : '',
-          rate: rateElement && rateElement.textContent ? rateElement.textContent.trim() : '',
-          stack: []
-        };
-
-        if (summary.title) {
-          summary.items.push({ label: 'Titre', value: summary.title });
-        }
-
-        if (summary.location) {
-          summary.items.push({ label: 'Lieu / Remote', value: summary.location });
-        }
-
-        if (summary.contract) {
-          summary.items.push({ label: 'Contrat', value: summary.contract });
-        }
-
-        if (summary.rate) {
-          summary.items.push({ label: 'Taux', value: summary.rate });
-        }
-
-        const normalizedStack = [];
-        stackElements.forEach((text) => {
-          const trimmed = text.trim().toLowerCase();
-          STACK_KEYWORDS.forEach((keyword) => {
-            if (trimmed.includes(keyword) && !normalizedStack.includes(keyword)) {
-              normalizedStack.push(keyword);
-            }
-          });
-        });
-
-        if (normalizedStack.length > 0) {
-          summary.stack = normalizedStack;
-          summary.items.push({ label: 'Stack', value: normalizedStack.join(' · ') });
-        }
-
-        return {
-          summary,
-          offer: {
-            title: summary.title,
-            location: summary.location,
-            contract: summary.contract,
-            rate: summary.rate,
-            stack: summary.stack
-          }
-        };
-      });
-
-      evidence.push(`Lecture directe des cartes listées (${offers.length} indices).`);
-      return { kind: 'list', offers };
-    }
-
-    const mainTitle = document.querySelector('h1');
-
-    if (mainTitle && mainTitle.textContent) {
-      const container = mainTitle.closest('article, main, section') || document.body;
-      const locationElement = container.querySelector('[data-testid*="location" i], [class*="location" i]');
-      const contractElement = container.querySelector('[data-testid*="contract" i], [class*="contrat" i]');
-      const rateElement = container.querySelector('[data-testid*="rate" i], [class*="tarif" i], [class*="salaire" i]');
-      const description = container.querySelector('section, div');
-
-      const job = {
-        title: mainTitle.textContent.trim(),
-        jobLocation: locationElement && locationElement.textContent ? locationElement.textContent.trim() : '',
-        employmentType: contractElement && contractElement.textContent ? contractElement.textContent.trim() : '',
-        baseSalary: rateElement && rateElement.textContent ? { value: rateElement.textContent.trim() } : undefined,
-        description: description && description.textContent ? description.textContent.trim().slice(0, 2400) : ''
-      };
-
-      const summary = summarizeJob(job);
-      evidence.push('Résumé construit depuis la structure visible (fallback DOM).');
-      return { kind: 'detail', offers: [{ summary, offer: job }] };
-    }
-
-    return { kind: 'none' };
-  }
-
-  function analyzeDocument() {
-    const evidence = [];
-    const url = window.location.href;
-
-    if (!isFreeWorkHost(url)) {
-      evidence.push('Hôte actuel : ' + url);
-      return {
-        kind: 'out_of_scope',
-        evidence
-      };
-    }
-
-    const { jobPostings, itemLists } = parseJsonLdScripts();
-
-    if (jobPostings.length > 0) {
-      const job = jobPostings[0];
-      const summary = summarizeJob(job);
-      evidence.push('Trouvé JSON-LD JobPosting.');
-
-      const offers = [
-        {
-          summary,
-          offer: job
-        }
-      ];
-
-      return {
-        kind: 'detail',
-        offers,
-        evidence,
-        source: 'json-ld'
-      };
-    }
-
-    if (itemLists.length > 0) {
-      const list = itemLists[0];
-      const offers = summarizeList(list);
-      const filteredOffers = offers.filter((entry) => entry.summary.items.length > 0);
-
-      if (filteredOffers.length > 0) {
-        evidence.push(`Trouvé JSON-LD ItemList avec ${filteredOffers.length} offres.`);
-        return {
-          kind: 'list',
-          offers: filteredOffers,
-          evidence,
-          source: 'json-ld'
-        };
-      }
-    }
-
-    const fallback = detectFromDom(evidence);
-
-    if (fallback.kind !== 'none') {
-      return {
-        kind: fallback.kind,
-        offers: fallback.offers,
-        evidence,
-        source: 'dom'
-      };
-    }
-
-    if (document.readyState !== 'complete') {
-      evidence.push('Le document n\'est pas encore complètement chargé.');
-      return {
-        kind: 'pending',
-        reason: 'contenu tardif',
-        evidence
-      };
-    }
-
-    const loadingIndicators = document.querySelector('[data-testid*="skeleton" i], [class*="skeleton" i], [aria-busy="true"]');
-
-    if (loadingIndicators) {
-      evidence.push('Présence de composants skeleton ou aria-busy.');
-      return {
-        kind: 'pending',
-        reason: 'contenu tardif',
-        evidence
-      };
-    }
-
-    evidence.push('Structure atypique : aucun schéma JSON-LD ni motif d\'offre identifié.');
+  });
+  return collected;
+}
+function formatLabel(label) {
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+// src/lib/result-mapper.ts
+function mapDetectionOutcome(outcome, context) {
+  if (outcome.status === "out_of_scope") {
     return {
-      kind: 'none',
-      reason: 'structure atypique',
+      kind: "out_of_scope",
+      evidence: [`URL analys\xE9e : ${context.url}`]
+    };
+  }
+  if (outcome.status === "ok") {
+    const summary = buildSummary(outcome.pageType, outcome.offers);
+    const evidence = flattenEvidence(outcome.offers);
+    const rawJson = {
+      url: context.url,
+      detectedAt: context.detectedAt,
+      status: outcome.status,
+      pageType: outcome.pageType,
+      offers: outcome.offers,
+      diagnostics: outcome.diagnostics,
+      evidence,
+      source: "detector"
+    };
+    return {
+      kind: outcome.pageType === "detail" ? "detail" : "list",
+      offersCount: outcome.offers.length,
+      summary,
+      rawJson,
       evidence
     };
   }
-
-  function buildPayload(result) {
-    if (result.kind !== 'detail' && result.kind !== 'list') {
-      return result;
-    }
-
-    const offers = result.offers.map((entry) => {
-      const summary = entry.summary;
-      const offer = entry.offer;
-      return {
-        title: summary.title || extractText(offer.title || offer.name),
-        location: summary.location || deriveLocation(offer),
-        contract: summary.contract || deriveContract(offer),
-        rate: summary.rate || formatRate(offer.baseSalary || offer.estimatedSalary),
-        stack: summary.stack && summary.stack.length > 0 ? summary.stack : extractStack(offer)
-      };
-    });
-
-    const summaryItems = [];
-
-    if (result.kind === 'detail' && offers[0]) {
-      const detail = offers[0];
-      if (detail.title) {
-        summaryItems.push({ label: 'Titre', value: detail.title });
-      }
-      if (detail.location) {
-        summaryItems.push({ label: 'Lieu / Remote', value: detail.location });
-      }
-      if (detail.contract) {
-        summaryItems.push({ label: 'Contrat', value: detail.contract });
-      }
-      if (detail.rate) {
-        summaryItems.push({ label: 'Taux', value: detail.rate });
-      }
-      if (detail.stack && detail.stack.length > 0) {
-        summaryItems.push({ label: 'Stack', value: detail.stack.join(' · ') });
-      }
-    } else {
-      offers.slice(0, 3).forEach((offer, index) => {
-        const parts = [offer.title, offer.location, offer.rate].filter(Boolean);
-        const label = `${index + 1}.`;
-        const value = parts.join(' — ') || 'Offre détectée';
-        summaryItems.push({ label, value });
-      });
-    }
-
-    const rawJson = {
-      url: window.location.href,
-      detectedAt: new Date().toISOString(),
-      pageType: result.kind,
-      offers,
-      evidence: result.evidence,
-      source: result.source || 'dom'
-    };
-
+  const reason = outcome.diagnostics?.reason;
+  if (outcome.status === "content_delayed") {
     return {
-      kind: result.kind,
-      offersCount: offers.length,
-      summary: {
-        items: summaryItems
-      },
-      rawJson,
-      evidence: result.evidence
+      kind: "pending",
+      reason: reason ?? "contenu tardif",
+      evidence: ["Contenu encore en chargement d\xE9tect\xE9 par le moteur FreeWork."]
     };
   }
+  return {
+    kind: "none",
+    reason,
+    evidence: reason ? [`Motif : ${reason}.`] : []
+  };
+}
 
-  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (!message || message.type !== 'FREELANCEFINDER_ANALYZE') {
-      return;
-    }
+// src/lib/detector-loader.ts
+var detectorPromise = null;
+var importer = defaultImporter;
+async function loadDetector() {
+  if (!detectorPromise) {
+    detectorPromise = importer().then(validateModule);
+  }
+  try {
+    return await detectorPromise;
+  } catch (error) {
+    detectorPromise = null;
+    throw error;
+  }
+}
+function validateModule(module) {
+  if (typeof module.detectFreeWorkOffers !== "function") {
+    throw new Error("detector_export_missing");
+  }
+  return module.detectFreeWorkOffers;
+}
+function defaultImporter() {
+  const runtime = globalThis.chrome?.runtime;
+  if (!runtime || typeof runtime.getURL !== "function") {
+    throw new Error("chrome_runtime_unavailable");
+  }
+  return import(runtime.getURL("detector.js"));
+}
 
-    try {
-      const analysis = analyzeDocument();
-      const payload = buildPayload(analysis);
-      sendResponse(payload);
-    } catch (error) {
-      sendResponse({
-        kind: 'none',
-        reason: 'erreur inattendue',
-        evidence: ['Une erreur interne a interrompu la détection.']
-      });
-    }
-
-    return true;
+// src/content-script.ts
+var MESSAGE_TYPE = "FREELANCEFINDER_ANALYZE";
+async function analyzeCurrentDocument() {
+  const url = window.location.href;
+  const detect = await loadDetector();
+  const outcome = await detect(document, { url });
+  const context = { url, detectedAt: (/* @__PURE__ */ new Date()).toISOString() };
+  return mapDetectionOutcome(outcome, context);
+}
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!message || message.type !== MESSAGE_TYPE) {
+    return;
+  }
+  analyzeCurrentDocument().then((result) => sendResponse(result)).catch(() => {
+    sendResponse({
+      kind: "none",
+      reason: "erreur inattendue",
+      evidence: ["Une erreur interne a interrompu la d\xE9tection."]
+    });
   });
-})();
+  return true;
+});

--- a/apps/extension-demo/detector.js
+++ b/apps/extension-demo/detector.js
@@ -1,0 +1,899 @@
+// ../../packages/detectors/src/utils/time.ts
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function timestamp(options) {
+  const nowProvider = options.now ?? (() => /* @__PURE__ */ new Date());
+  return nowProvider().getTime();
+}
+
+// ../../packages/detectors/src/state/poller.ts
+async function pollUntil(options, config, check, isReady) {
+  const start = timestamp(options);
+  const deadline = start + config.maxWaitMs;
+  let attempts = 1;
+  let value = check();
+  if (isReady(value)) {
+    const waited = Math.max(0, timestamp(options) - start);
+    return { value, attempts, waitedMs: waited };
+  }
+  for (let now = start; now < deadline; now = timestamp(options)) {
+    const remaining = Math.max(0, deadline - now);
+    const waitDuration = Math.min(config.pollIntervalMs, remaining);
+    if (waitDuration > 0) {
+      await delay(waitDuration);
+    }
+    attempts += 1;
+    value = check();
+    if (isReady(value)) {
+      const waited = Math.max(0, timestamp(options) - start);
+      return { value, attempts, waitedMs: waited };
+    }
+  }
+  const waitedMs = Math.max(0, timestamp(options) - start);
+  return { value, attempts, waitedMs };
+}
+
+// ../../packages/detectors/src/utils/url.ts
+var FREEWORK_HOST_SUFFIX = "free-work.com";
+function safeParseUrl(url) {
+  try {
+    return new URL(url);
+  } catch (error) {
+    return null;
+  }
+}
+function isFreeWorkDomain(url) {
+  return url.hostname.endsWith(FREEWORK_HOST_SUFFIX);
+}
+function toAbsoluteUrl(href, base) {
+  try {
+    return new URL(href, base).toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+// ../../packages/detectors/src/parsing/heading.ts
+function findMainHeading(root) {
+  const heading = root.querySelector("h1") ?? root.querySelector("h2");
+  return heading;
+}
+
+// ../../packages/detectors/src/normalize/text.ts
+function normalizeText(value) {
+  return value ? value.replace(/\s+/g, " ").trim() : "";
+}
+function truncate(value, max = 800) {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max).trimEnd()}\u2026`;
+}
+
+// ../../packages/detectors/src/parsing/meta.ts
+function collectMetaTexts(root) {
+  const selectors = [".meta", "[class*='meta']", "[class*='info']", "header", "ul", "dl"];
+  const collected = /* @__PURE__ */ new Set();
+  for (const selector of selectors) {
+    const scope = root instanceof Document ? root : root;
+    const elements = scope.querySelectorAll(selector);
+    for (const element of elements) {
+      const nodes = element.querySelectorAll("span, div, li, dt, dd, p");
+      for (const child of Array.from(nodes)) {
+        const text = normalizeText(child.textContent);
+        if (!text || text.length > 140) continue;
+        collected.add(text);
+      }
+    }
+  }
+  if (root instanceof Element) {
+    const inlineCandidates = root.querySelectorAll("span, li, p");
+    for (const node of Array.from(inlineCandidates)) {
+      const text = normalizeText(node.textContent);
+      if (!text || text.length > 140) continue;
+      collected.add(text);
+    }
+  }
+  return Array.from(collected);
+}
+function findByLabel(metaTexts, label) {
+  for (const text of metaTexts) {
+    const match = text.match(label);
+    if (match) {
+      const parts = text.split(/[:-]/);
+      if (parts.length > 1) {
+        return normalizeText(parts.slice(1).join(":"));
+      }
+      const after = text.slice((match.index ?? 0) + match[0].length).trim();
+      if (after) {
+        return normalizeText(after);
+      }
+      return text;
+    }
+  }
+  return void 0;
+}
+function findExperience(metaTexts) {
+  for (const text of metaTexts) {
+    if (/exp[eé]rience/i.test(text) || /junior/i.test(text) || /senior/i.test(text) || /\b\d+\s*(ans|years)/i.test(text)) {
+      return text;
+    }
+  }
+  return void 0;
+}
+function findPostedAt(metaTexts) {
+  for (const text of metaTexts) {
+    if (/publi[eé]e?/i.test(text) || /post[eé]e?/i.test(text) || /il y a/i.test(text)) {
+      return text;
+    }
+  }
+  return void 0;
+}
+
+// ../../packages/detectors/src/parsing/contract.ts
+var CONTRACT_PATTERNS = [
+  { pattern: /freelance/i, label: "Freelance" },
+  { pattern: /cdi/i, label: "CDI" },
+  { pattern: /cdd/i, label: "CDD" },
+  { pattern: /portage/i, label: "Portage" },
+  { pattern: /stage/i, label: "Stage" },
+  { pattern: /alternance/i, label: "Alternance" }
+];
+function findContractType(metaTexts) {
+  for (const { pattern, label } of CONTRACT_PATTERNS) {
+    if (metaTexts.some((text) => pattern.test(text))) {
+      return label;
+    }
+  }
+  return void 0;
+}
+
+// ../../packages/detectors/src/normalize/remote.ts
+var REMOTE_PATTERNS = [
+  /full\s*remote/i,
+  /remote/i,
+  /télétravail/i,
+  /teletravail/i,
+  /hybride/i,
+  /home\s*office/i
+];
+function detectRemote(texts) {
+  for (const text of texts) {
+    if (!text) continue;
+    for (const pattern of REMOTE_PATTERNS) {
+      if (pattern.test(text)) {
+        return { isRemote: true, snippet: text, policy: normalizeRemotePolicy(text) };
+      }
+    }
+  }
+  return { isRemote: false };
+}
+function normalizeRemotePolicy(text) {
+  const normalized = text.toLowerCase();
+  if (normalized.includes("hybride")) {
+    return "hybrid";
+  }
+  if (normalized.includes("full")) {
+    return "full-remote";
+  }
+  if (normalized.includes("remote") || normalized.includes("t\xE9l\xE9travail") || normalized.includes("teletravail")) {
+    return "remote";
+  }
+  return void 0;
+}
+
+// ../../packages/detectors/src/normalize/rate.ts
+var RATE_KEYWORDS = /(jour|day|mois|month|an|year|semaine|week|heure|hour)/i;
+var RATE_NUMERIC_PATTERN = /(\d+[\d\s,.]*)/;
+function looksLikeRate(text) {
+  return /€|eur|\beuros?|\btjm/i.test(text) && /\d/.test(text);
+}
+function parseRate(rawText) {
+  const raw = normalizeText(rawText);
+  if (!raw) return void 0;
+  const valueMatch = raw.match(RATE_NUMERIC_PATTERN);
+  const periodMatch = raw.match(RATE_KEYWORDS);
+  let value;
+  if (valueMatch) {
+    const numeric = valueMatch[1].replace(/[\s,]/g, (char) => char === "," ? "." : "");
+    const parsed = Number.parseFloat(numeric);
+    if (!Number.isNaN(parsed)) {
+      value = Number(parsed.toFixed(2));
+    }
+  }
+  const currency = /€/.test(raw) ? "EUR" : /\bchf\b/i.test(raw) ? "CHF" : /\busd\b|\$/.test(raw) ? "USD" : void 0;
+  const period = periodMatch ? normalizePeriod(periodMatch[0]) : void 0;
+  return { raw, value, currency, period };
+}
+function normalizePeriod(token) {
+  const lowered = token.toLowerCase();
+  if (lowered.startsWith("jour") || lowered.startsWith("day")) {
+    return "day";
+  }
+  if (lowered.startsWith("mois") || lowered.startsWith("month")) {
+    return "month";
+  }
+  if (lowered.startsWith("semaine") || lowered.startsWith("week")) {
+    return "week";
+  }
+  if (lowered.includes("heure") || lowered.includes("hour")) {
+    return "hour";
+  }
+  return "year";
+}
+
+// ../../packages/detectors/src/normalize/location.ts
+var LOCATION_KEYWORDS = [
+  "paris",
+  "lyon",
+  "marseille",
+  "toulouse",
+  "bordeaux",
+  "nantes",
+  "lille",
+  "rennes",
+  "grenoble",
+  "strasbourg",
+  "montpellier",
+  "nice",
+  "sophia",
+  "niort",
+  "brest",
+  "dijon",
+  "tours",
+  "angers",
+  "rouen",
+  "saint",
+  "t\xE9l\xE9travail",
+  "remote",
+  "hybride",
+  "france",
+  "idf"
+];
+function findLocation(metaTexts, options) {
+  for (const text of metaTexts) {
+    if (!text) continue;
+    if (!options.includeRemote && REMOTE_PATTERNS.some((pattern) => pattern.test(text))) {
+      continue;
+    }
+    if (looksLikeRate(text) || /dur[eé]e/i.test(text) || /d[eé]marrage/i.test(text) || /exp[eé]rience/i.test(text)) {
+      continue;
+    }
+    const lower = text.toLowerCase();
+    if (/freelance|cdi|cdd|stage|alternance|portage/.test(lower)) {
+      continue;
+    }
+    if (LOCATION_KEYWORDS.some((keyword) => lower.includes(keyword))) {
+      return text;
+    }
+    if (/\d{5}/.test(text) && /[A-Za-z]/.test(text)) {
+      return text;
+    }
+    const words = lower.split(/[,•-]/).map((part) => part.trim());
+    for (const word of words) {
+      if (word.length >= 3 && /^[a-zéèêàùâûç\s]+$/.test(word) && word.split(" ").length <= 3) {
+        if (!looksLikeRate(word) && !/exp[eé]rience|dur[eé]e|d[eé]marrage/.test(word)) {
+          return text;
+        }
+      }
+    }
+  }
+  return void 0;
+}
+
+// ../../packages/detectors/src/parsing/tags.ts
+function collectTags(root) {
+  const selectors = [".tag", "[class*='tag']", "[class*='skill']", "[class*='stack']", "[data-tag]"];
+  const tags = /* @__PURE__ */ new Set();
+  for (const selector of selectors) {
+    const scope = root instanceof Document ? root : root;
+    const elements = scope.querySelectorAll(selector);
+    for (const element of elements) {
+      const text = normalizeText(element.textContent);
+      if (!text || text.length > 40) continue;
+      const className = element.getAttribute("class")?.toLowerCase() ?? "";
+      const classes = className.split(/\s+/);
+      if (classes.some((cls) => cls === "tags" || cls === "tags-list" || cls === "tag-list")) {
+        continue;
+      }
+      if (element.childElementCount > 0) {
+        const hasTagChild = Array.from(element.children).some((child) => {
+          const childClass = child.getAttribute("class")?.toLowerCase() ?? "";
+          return childClass.includes("tag");
+        });
+        if (hasTagChild) {
+          continue;
+        }
+      }
+      if (/^tag$/i.test(text)) continue;
+      tags.add(text);
+    }
+  }
+  return Array.from(tags);
+}
+
+// ../../packages/detectors/src/parsing/company.ts
+function extractCompany(root) {
+  const headings = Array.from(root.querySelectorAll("h2, h3, strong"));
+  for (const heading of headings) {
+    const text = normalizeText(heading.textContent);
+    if (!text) continue;
+    if (/soci[eé]t[eé]|entreprise|client/i.test(text)) {
+      const nextText = normalizeText(getFollowingText(heading));
+      if (nextText) {
+        return nextText;
+      }
+    }
+  }
+  return void 0;
+}
+function getFollowingText(element) {
+  let node = element.nextElementSibling;
+  while (node) {
+    const text = normalizeText(node.textContent);
+    if (text) {
+      return text;
+    }
+    node = node.nextElementSibling;
+  }
+  return "";
+}
+
+// ../../packages/detectors/src/parsing/description.ts
+function extractDescription(main) {
+  const container = main instanceof Document ? main.body : main;
+  if (!container) return void 0;
+  const candidates = Array.from(container.querySelectorAll("article, section, div"));
+  let bestText = "";
+  let bestScore = 0;
+  for (const candidate of candidates) {
+    const text = normalizeText(candidate.textContent);
+    if (text.length < 80) continue;
+    const className = candidate.getAttribute("class")?.toLowerCase() ?? "";
+    const dataSection = candidate.getAttribute("data-section")?.toLowerCase() ?? "";
+    let score = text.length;
+    if (/description|mission|detail|content|job-body|presentation/.test(className + dataSection)) {
+      score += 250;
+    }
+    if (candidate.querySelector("p")) {
+      score += 50;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestText = text;
+    }
+  }
+  if (!bestText) {
+    const fallback = normalizeText(container.textContent);
+    if (fallback.length >= 120) {
+      bestText = fallback;
+    }
+  }
+  if (!bestText) {
+    return void 0;
+  }
+  return truncate(bestText, 900);
+}
+
+// ../../packages/detectors/src/parsing/technologies.ts
+var TECHNOLOGY_PATTERNS = [
+  { label: "Node.js", pattern: /node\.?js/i },
+  { label: "React", pattern: /react/i },
+  { label: "TypeScript", pattern: /typescript|ts\b/i },
+  { label: "JavaScript", pattern: /javascript/i },
+  { label: "AWS", pattern: /\baws\b/i },
+  { label: "Azure", pattern: /azure/i },
+  { label: "GCP", pattern: /\bgoogle cloud|\bgcp\b/i },
+  { label: "Kubernetes", pattern: /kubernetes|k8s/i },
+  { label: "Docker", pattern: /docker/i },
+  { label: "Terraform", pattern: /terraform/i },
+  { label: "Java", pattern: /\bjava\b/i },
+  { label: "Spring", pattern: /spring\b/i },
+  { label: "Python", pattern: /python/i },
+  { label: "Django", pattern: /django/i },
+  { label: "Flask", pattern: /flask/i },
+  { label: "PHP", pattern: /\bphp\b/i },
+  { label: "Symfony", pattern: /symfony/i },
+  { label: "Laravel", pattern: /laravel/i },
+  { label: "Go", pattern: /\bgo\b|golang/i },
+  { label: "Rust", pattern: /rust/i },
+  { label: "C#", pattern: /c#/i },
+  { label: "C++", pattern: /c\+\+/i },
+  { label: "Ruby", pattern: /ruby/i },
+  { label: "Rails", pattern: /rails/i },
+  { label: "Scala", pattern: /scala/i },
+  { label: "Swift", pattern: /swift/i },
+  { label: "Kotlin", pattern: /kotlin/i },
+  { label: "Android", pattern: /android/i },
+  { label: "iOS", pattern: /\bios\b/i },
+  { label: "Angular", pattern: /angular/i },
+  { label: "Vue", pattern: /vue\.js|vuejs|\bvue\b/i },
+  { label: "Svelte", pattern: /svelte/i },
+  { label: "GraphQL", pattern: /graphql/i },
+  { label: "PostgreSQL", pattern: /postgresql|postgres/i },
+  { label: "MySQL", pattern: /mysql/i },
+  { label: "MongoDB", pattern: /mongodb/i },
+  { label: "Redis", pattern: /redis/i },
+  { label: "Kafka", pattern: /kafka/i },
+  { label: "Spark", pattern: /spark/i },
+  { label: "Hadoop", pattern: /hadoop/i },
+  { label: "Elasticsearch", pattern: /elasticsearch|elastic/i }
+];
+function detectTechnologiesFromTexts(texts, stack) {
+  for (const text of texts) {
+    if (!text) continue;
+    for (const tech of TECHNOLOGY_PATTERNS) {
+      if (tech.pattern.test(text)) {
+        stack.add(tech.label);
+      }
+    }
+  }
+}
+
+// ../../packages/detectors/src/utils/selectors.ts
+function buildSelector(element) {
+  const segments = [];
+  let current = element;
+  while (current && segments.length < 4) {
+    let segment = current.tagName.toLowerCase();
+    if (current.id) {
+      segment += `#${current.id}`;
+      segments.unshift(segment);
+      break;
+    }
+    if (current.classList.length > 0) {
+      segment += `.${Array.from(current.classList).slice(0, 2).join(".")}`;
+    }
+    segments.unshift(segment);
+    current = current.parentElement;
+  }
+  return segments.join(" > ");
+}
+
+// ../../packages/detectors/src/state/evidence.ts
+function populateEvidence(offer, titleElement, parts) {
+  const evidence = [];
+  pushEvidence(evidence, "title", offer.title, titleElement ? buildSelector(titleElement) : void 0);
+  if (parts.rateText) {
+    pushEvidence(evidence, "rate", parts.rateText);
+  }
+  if (parts.location) {
+    pushEvidence(evidence, "location", parts.location);
+  }
+  if (offer.rate?.raw && !parts.rateText) {
+    pushEvidence(evidence, "rate", offer.rate.raw);
+  }
+  if (parts.contractType) {
+    pushEvidence(evidence, "contract", parts.contractType);
+  }
+  if (parts.startDate) {
+    pushEvidence(evidence, "startDate", parts.startDate);
+  }
+  if (parts.duration) {
+    pushEvidence(evidence, "duration", parts.duration);
+  }
+  if (parts.experienceLevel) {
+    pushEvidence(evidence, "experience", parts.experienceLevel);
+  }
+  if (parts.postedAt) {
+    pushEvidence(evidence, "postedAt", parts.postedAt);
+  }
+  if (parts.remoteSnippet) {
+    pushEvidence(evidence, "remote", parts.remoteSnippet);
+  }
+  if (parts.descriptionSnippet) {
+    pushEvidence(evidence, "description", truncate(parts.descriptionSnippet, 180));
+  }
+  if (parts.tags && parts.tags.length > 0) {
+    pushEvidence(evidence, "tags", parts.tags.slice(0, 3).join(", "));
+  }
+  if (evidence.length < 3 && offer.description) {
+    pushEvidence(evidence, "context", truncate(offer.description, 160));
+  }
+  if (evidence.length < 3 && offer.rate?.raw) {
+    pushEvidence(evidence, "pricing", offer.rate.raw);
+  }
+  if (evidence.length < 3 && offer.location) {
+    pushEvidence(evidence, "geo", offer.location);
+  }
+  offer.evidence = evidence;
+}
+function pushEvidence(list, label, snippet, selector) {
+  if (!snippet) return;
+  const normalized = truncate(snippet, 220);
+  list.push({ label, snippet: normalized, selector });
+}
+
+// ../../packages/detectors/src/state/confidence.ts
+function computeConfidence(params) {
+  let score = 0.25;
+  if (params.hasTitle) score += 0.2;
+  if (params.hasRate) score += 0.15;
+  if (params.hasLocationOrRemote) score += 0.15;
+  if (params.stackCount >= 2) score += 0.1;
+  else if (params.stackCount === 1) score += 0.05;
+  if (params.descriptionLength >= 180) score += 0.1;
+  else if (params.descriptionLength >= 60) score += 0.05;
+  if (params.hasContract) score += 0.05;
+  return Math.min(1, Math.max(0, score));
+}
+
+// ../../packages/detectors/src/freework/detail.ts
+function extractDetailOffer(document, pageUrl) {
+  const main = resolveDetailRoot(document);
+  if (!main) {
+    return { offer: null, ready: false, reason: "structure introuvable" };
+  }
+  const heading = findMainHeading(main);
+  const title = heading ? normalizeText(heading.textContent) : "";
+  if (!isValidTitle(title)) {
+    return { offer: null, ready: false, reason: "titre absent" };
+  }
+  const metaData = buildMetaData(main);
+  const description = extractDescription(main);
+  const tags = collectTags(main);
+  const stack = buildStack(metaData.texts, description, tags);
+  const offer = assembleOffer({
+    pageUrl,
+    title,
+    company: extractCompany(main),
+    description,
+    tags,
+    stack,
+    metaData
+  });
+  applyConfidence(offer, stack.length, description?.length ?? 0, metaData);
+  populateEvidence(offer, heading, buildEvidence(metaData, description, tags));
+  const readiness = evaluateReadiness(stack.length, description?.length ?? 0, metaData);
+  return { offer, ready: readiness.ready, reason: readiness.reason };
+}
+function resolveDetailRoot(document) {
+  return document.querySelector("main") ?? document.body;
+}
+function isValidTitle(value) {
+  return Boolean(value && value.trim().length >= 6);
+}
+function buildMetaData(main) {
+  const texts = collectMetaTexts(main);
+  const rateText = texts.find(looksLikeRate);
+  const rate = rateText ? parseRate(rateText) : void 0;
+  const contractType = findContractType(texts);
+  let location = findLocation(texts, { includeRemote: false });
+  const remote = detectRemote([...texts, location ?? ""]);
+  if (!location && remote.snippet) {
+    location = remote.snippet;
+  }
+  return {
+    texts,
+    rateText,
+    rate,
+    contractType,
+    location,
+    remote,
+    startDate: findByLabel(texts, /(d[eé]marrage|d[eé]but|start)/i),
+    duration: findByLabel(texts, /dur[eé]e/i),
+    experienceLevel: findExperience(texts),
+    postedAt: findPostedAt(texts)
+  };
+}
+function buildStack(metaTexts, description, tags) {
+  const stackSet = new Set(tags);
+  detectTechnologiesFromTexts([...metaTexts, description ?? ""], stackSet);
+  return Array.from(stackSet);
+}
+function assembleOffer(params) {
+  const { pageUrl, title, company, description, tags, stack, metaData } = params;
+  return {
+    source: "FreeWork",
+    url: pageUrl.toString(),
+    title,
+    company,
+    location: metaData.location,
+    isRemote: metaData.remote.isRemote,
+    remotePolicy: metaData.remote.policy,
+    contractType: metaData.contractType,
+    rate: metaData.rate,
+    startDate: metaData.startDate,
+    duration: metaData.duration,
+    experienceLevel: metaData.experienceLevel,
+    stack,
+    description,
+    postedAt: metaData.postedAt,
+    tags,
+    confidence: 0,
+    evidence: []
+  };
+}
+function applyConfidence(offer, stackCount, descriptionLength, metaData) {
+  offer.confidence = computeConfidence({
+    hasTitle: Boolean(offer.title),
+    hasRate: Boolean(metaData.rate),
+    hasLocationOrRemote: Boolean(metaData.location || metaData.remote.isRemote),
+    stackCount,
+    descriptionLength,
+    hasContract: Boolean(metaData.contractType)
+  });
+}
+function buildEvidence(metaData, description, tags) {
+  return {
+    rateText: metaData.rateText,
+    location: metaData.location,
+    contractType: metaData.contractType,
+    startDate: metaData.startDate,
+    duration: metaData.duration,
+    experienceLevel: metaData.experienceLevel,
+    postedAt: metaData.postedAt,
+    remoteSnippet: metaData.remote.snippet,
+    descriptionSnippet: description,
+    tags
+  };
+}
+function evaluateReadiness(stackCount, descriptionLength, metaData) {
+  const essentialSignals = [
+    Boolean(metaData.rate),
+    Boolean(metaData.location || metaData.remote.isRemote),
+    stackCount >= 2,
+    descriptionLength >= 150
+  ];
+  const ready = essentialSignals.filter(Boolean).length >= 2 && descriptionLength >= 120;
+  return ready ? { ready } : { ready: false, reason: "informations partielles" };
+}
+
+// ../../packages/detectors/src/parsing/cards.ts
+function splitSegments(text) {
+  return text.split(/\n|•|\||,|;|\u2022/).map((segment) => normalizeText(segment)).filter((segment) => Boolean(segment));
+}
+function buildCardSnippet(card, title) {
+  const text = normalizeText(card.textContent);
+  if (!text) return "";
+  const cleaned = text.replace(title, "").trim();
+  const snippet = cleaned.length > 0 ? cleaned : text;
+  return truncate(snippet, 320);
+}
+
+// ../../packages/detectors/src/utils/collections.ts
+function uniqueStrings(values) {
+  const set = /* @__PURE__ */ new Set();
+  for (const value of values) {
+    if (!value) continue;
+    set.add(value);
+  }
+  return Array.from(set);
+}
+
+// ../../packages/detectors/src/freework/list.ts
+function extractListOffers(document, pageUrl) {
+  const offers = [];
+  const cards = findOfferCards(document);
+  for (const card of cards) {
+    const offer = buildOfferFromCard(card, pageUrl);
+    if (offer) {
+      offers.push(offer);
+    }
+  }
+  return offers;
+}
+function findOfferCards(document) {
+  const seen = /* @__PURE__ */ new Set();
+  const cards = [];
+  const anchors = Array.from(document.querySelectorAll("a[href]"));
+  for (const anchor of anchors) {
+    const href = anchor.getAttribute("href");
+    if (!href || !/\bjob\b/i.test(href)) {
+      continue;
+    }
+    const titleElement = anchor.querySelector("h1, h2, h3, h4, h5") ?? anchor;
+    const title = normalizeText(titleElement.textContent);
+    if (!title || title.length < 5 || /postuler/i.test(title)) {
+      continue;
+    }
+    const root = anchor.closest("article, li, section, div") ?? anchor;
+    if (seen.has(root)) {
+      continue;
+    }
+    seen.add(root);
+    cards.push({ root, anchor, title });
+  }
+  return cards;
+}
+function buildOfferFromCard(card, pageUrl) {
+  const absoluteUrl = toAbsoluteUrl(card.anchor.getAttribute("href") ?? "", pageUrl);
+  if (!absoluteUrl) {
+    return null;
+  }
+  const segments = collectCardSegments(card);
+  const meta = deriveMetaData(segments);
+  const tags = collectTags(card.root);
+  const stack = buildCardStack(card.title, segments, tags);
+  const snippet = buildCardSnippet(card.root, card.title);
+  const offer = {
+    source: "FreeWork",
+    url: absoluteUrl,
+    title: card.title,
+    location: meta.location,
+    isRemote: meta.remote.isRemote,
+    remotePolicy: meta.remote.policy,
+    contractType: meta.contractType,
+    rate: meta.rate,
+    stack,
+    description: snippet,
+    tags: uniqueStrings([...tags, ...stack]),
+    confidence: 0,
+    evidence: []
+  };
+  applyCardConfidence(offer, stack.length, snippet.length, meta);
+  populateEvidence(offer, card.anchor, buildCardEvidence(meta, snippet, offer.tags));
+  return offer;
+}
+function collectCardSegments(card) {
+  const cardText = normalizeText(card.root.textContent);
+  const segments = splitSegments(cardText);
+  const metaCandidates = collectMetaTexts(card.root);
+  return uniqueStrings([...segments, ...metaCandidates]);
+}
+function deriveMetaData(segments) {
+  const rateText = segments.find(looksLikeRate);
+  const rate = rateText ? parseRate(rateText) : void 0;
+  let location = findLocation(segments, { includeRemote: true });
+  const remote = detectRemote(segments);
+  if (!location && remote.snippet) {
+    location = remote.snippet;
+  }
+  return {
+    rateText,
+    rate,
+    location,
+    remote,
+    contractType: findContractType(segments)
+  };
+}
+function buildCardStack(title, segments, tags) {
+  const stackSet = /* @__PURE__ */ new Set();
+  detectTechnologiesFromTexts([title, ...segments], stackSet);
+  tags.forEach((tag) => stackSet.add(tag));
+  return Array.from(stackSet);
+}
+function applyCardConfidence(offer, stackCount, descriptionLength, meta) {
+  offer.confidence = computeConfidence({
+    hasTitle: Boolean(offer.title),
+    hasRate: Boolean(meta.rate),
+    hasLocationOrRemote: Boolean(meta.location || meta.remote.isRemote),
+    stackCount,
+    descriptionLength,
+    hasContract: Boolean(meta.contractType)
+  });
+}
+function buildCardEvidence(meta, snippet, tags) {
+  return {
+    rateText: meta.rateText,
+    location: meta.location,
+    contractType: meta.contractType,
+    descriptionSnippet: snippet,
+    remoteSnippet: meta.remote.snippet,
+    tags
+  };
+}
+
+// ../../packages/detectors/src/freework/detector.ts
+var DEFAULT_MAX_WAIT_MS = 1800;
+var DEFAULT_POLL_INTERVAL_MS = 40;
+async function detectFreeWorkOffers(document, options) {
+  const pageUrl = ensureFreeWorkUrl(options.url);
+  if (!pageUrl) {
+    return buildOutOfScopeOutcome();
+  }
+  const pollingConfig = resolvePollingConfig(options);
+  const pollResult = await pollUntil(
+    options,
+    pollingConfig,
+    () => analyseDocument(document, pageUrl),
+    isSuccessfulAnalysis
+  );
+  return finalizeOutcome(pollResult.value, pollResult);
+}
+function ensureFreeWorkUrl(rawUrl) {
+  const parsedUrl = safeParseUrl(rawUrl);
+  if (!parsedUrl || !isFreeWorkDomain(parsedUrl)) {
+    return null;
+  }
+  return parsedUrl;
+}
+function resolvePollingConfig(options) {
+  return {
+    maxWaitMs: options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS,
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  };
+}
+function isSuccessfulAnalysis(analysis) {
+  return analysis.ready && analysis.offers.length > 0;
+}
+function buildOutOfScopeOutcome() {
+  return {
+    status: "out_of_scope",
+    message: "Page hors p\xE9rim\xE8tre FreeWork",
+    pageType: "unknown",
+    offers: []
+  };
+}
+function finalizeOutcome(analysis, pollResult) {
+  if (analysis.offers.length > 0) {
+    return {
+      status: "ok",
+      message: analysis.message ?? buildSuccessMessage(analysis.pageType, analysis.offers.length),
+      pageType: analysis.pageType,
+      offers: analysis.offers,
+      diagnostics: {
+        attempts: pollResult.attempts,
+        waitedMs: pollResult.waitedMs
+      }
+    };
+  }
+  const reason = analysis.reason ?? "contenu insuffisant";
+  const status = reason === "contenu tardif" ? "content_delayed" : "no_offers";
+  return {
+    status,
+    message: `Aucune offre d\xE9tectable (${reason})`,
+    pageType: analysis.pageType,
+    offers: [],
+    diagnostics: {
+      attempts: pollResult.attempts,
+      waitedMs: pollResult.waitedMs,
+      reason
+    }
+  };
+}
+function analyseDocument(document, pageUrl) {
+  const detail = extractDetailOffer(document, pageUrl);
+  if (detail.offer && detail.ready) {
+    return {
+      pageType: "detail",
+      offers: [detail.offer],
+      ready: true,
+      message: "Offre d\xE9tect\xE9e (d\xE9tail)"
+    };
+  }
+  const listOffers = extractListOffers(document, pageUrl);
+  if (listOffers.length >= 2) {
+    return {
+      pageType: "list",
+      offers: listOffers,
+      ready: true,
+      message: `Liste d\xE9tect\xE9e : ${listOffers.length} offres`
+    };
+  }
+  if (detail.offer) {
+    return {
+      pageType: "detail",
+      offers: [],
+      ready: false,
+      reason: detail.reason ?? "informations partielles"
+    };
+  }
+  if (listOffers.length === 1) {
+    return {
+      pageType: "list",
+      offers: [],
+      ready: false,
+      reason: "une seule carte d\xE9tect\xE9e"
+    };
+  }
+  const hasHeading = Boolean(findMainHeading(document));
+  return {
+    pageType: "unknown",
+    offers: [],
+    ready: false,
+    reason: hasHeading ? "structure atypique" : "contenu tardif"
+  };
+}
+function buildSuccessMessage(pageType, count) {
+  if (pageType === "list") {
+    return `Liste d\xE9tect\xE9e : ${count} offres`;
+  }
+  if (pageType === "detail") {
+    return "Offre d\xE9tect\xE9e (d\xE9tail)";
+  }
+  return "D\xE9tection FreeWork";
+}
+
+export { detectFreeWorkOffers };

--- a/apps/extension-demo/manifest.json
+++ b/apps/extension-demo/manifest.json
@@ -15,5 +15,11 @@
       "js": ["content-script.js"],
       "run_at": "document_idle"
     }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["detector.js"],
+      "matches": ["https://*.free-work.com/*"]
+    }
   ]
 }

--- a/apps/extension-demo/package.json
+++ b/apps/extension-demo/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@freelancefinder/extension-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsup --config tsup.config.ts && cp dist/content-script.js ./content-script.js && cp dist/popup/popup.js ./popup.js && cp dist/detector-entry.js ./detector.js",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@freelancefinder/detectors": "workspace:*",
+    "@freelancefinder/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@freelancefinder/config": "workspace:*",
+    "@types/chrome": "^0.0.255",
+    "esbuild-plugin-alias": "^0.2.1",
+    "tsup": "^8.0.1",
+    "vitest": "^1.5.0"
+  }
+}

--- a/apps/extension-demo/popup.js
+++ b/apps/extension-demo/popup.js
@@ -1,61 +1,356 @@
-const statusContainer = document.getElementById('status');
-const statusEmoji = statusContainer.querySelector('.status-emoji');
-const statusText = document.getElementById('status-text');
-const analyzeButton = document.getElementById('analyze');
-const resetButton = document.getElementById('reset');
-const copyButton = document.getElementById('copy');
-const copyFeedback = document.getElementById('copy-feedback');
-const resultSection = document.getElementById('result');
-const summaryList = document.getElementById('summary');
-const jsonOutput = document.getElementById('json-output');
-const jsonPanel = document.getElementById('json-panel');
-const evidenceToggle = document.getElementById('toggle-evidence');
-const evidenceList = document.getElementById('evidence-list');
-const openTourButton = document.getElementById('open-tour');
-const tourDialog = document.getElementById('tour');
-const tourSteps = Array.from(tourDialog.querySelectorAll('.tour-step'));
-const tourPrev = document.getElementById('tour-prev');
-const tourNext = document.getElementById('tour-next');
-const tourClose = document.getElementById('tour-close');
-
-let activeTabId = null;
-let currentResult = null;
-let retryTimeout = null;
-let isAnalyzing = false;
-let tourIndex = 0;
-let isFreeWorkTab = false;
-
-function setStatus(emoji, text) {
-  statusEmoji.textContent = emoji;
-  statusText.textContent = text;
+// src/popup/dom.ts
+function getElements() {
+  const statusContainer = requireElement(document.getElementById("status"));
+  return {
+    statusContainer,
+    statusEmoji: requireElement(statusContainer.querySelector(".status-emoji")),
+    statusText: requireElement(document.getElementById("status-text")),
+    analyzeButton: requireElement(document.getElementById("analyze")),
+    resetButton: requireElement(document.getElementById("reset")),
+    copyButton: requireElement(document.getElementById("copy")),
+    copyFeedback: requireElement(document.getElementById("copy-feedback")),
+    resultSection: requireElement(document.getElementById("result")),
+    summaryList: requireElement(document.getElementById("summary")),
+    jsonOutput: requireElement(document.getElementById("json-output")),
+    jsonPanel: requireElement(document.getElementById("json-panel")),
+    evidenceToggle: requireElement(document.getElementById("toggle-evidence")),
+    evidenceList: requireElement(document.getElementById("evidence-list")),
+    openTourButton: requireElement(document.getElementById("open-tour")),
+    tourDialog: requireElement(document.getElementById("tour")),
+    tourSteps: Array.from(document.querySelectorAll(".tour-step")),
+    tourPrev: requireElement(document.getElementById("tour-prev")),
+    tourNext: requireElement(document.getElementById("tour-next")),
+    tourClose: requireElement(document.getElementById("tour-close"))
+  };
+}
+function requireElement(value) {
+  if (!value) {
+    throw new Error("popup_element_missing");
+  }
+  return value;
 }
 
-function disableAnalysis() {
-  analyzeButton.disabled = true;
+// src/popup/render.ts
+function setStatus(elements, info) {
+  elements.statusEmoji.textContent = info.emoji;
+  elements.statusText.textContent = info.text;
 }
-
-function enableAnalysis() {
-  analyzeButton.disabled = !isFreeWorkTab;
+function resetView(elements, activeTabId) {
+  elements.resultSection.hidden = true;
+  elements.summaryList.innerHTML = "";
+  elements.jsonOutput.textContent = "";
+  elements.jsonPanel.open = false;
+  elements.copyButton.disabled = true;
+  elements.evidenceToggle.disabled = true;
+  elements.evidenceToggle.setAttribute("aria-expanded", "false");
+  elements.evidenceToggle.textContent = "Voir les indices";
+  elements.evidenceList.hidden = true;
+  elements.evidenceList.innerHTML = "";
+  elements.copyFeedback.textContent = "";
+  elements.resetButton.disabled = true;
+  updateBadge(activeTabId, "");
 }
-
-function resetUiState() {
-  currentResult = null;
-  resultSection.hidden = true;
-  summaryList.innerHTML = '';
-  jsonOutput.textContent = '';
-  jsonPanel.open = false;
-  copyButton.disabled = true;
-  evidenceToggle.disabled = true;
-  evidenceToggle.setAttribute('aria-expanded', 'false');
-  evidenceList.hidden = true;
-  evidenceList.innerHTML = '';
-  copyFeedback.textContent = '';
-  resetButton.disabled = true;
-  if (activeTabId !== null) {
-    chrome.action.setBadgeText({ tabId: activeTabId, text: '' });
+function renderSuccess(elements, result, activeTabId) {
+  elements.resultSection.hidden = false;
+  elements.resetButton.disabled = false;
+  elements.copyButton.disabled = false;
+  renderSummary(elements, result);
+  renderEvidence(elements, result.evidence);
+  renderJson(elements, result.rawJson);
+  updateBadge(activeTabId, result.offersCount > 0 ? String(result.offersCount) : "");
+}
+function renderEvidence(elements, evidence) {
+  elements.evidenceList.innerHTML = "";
+  if (evidence.length === 0) {
+    elements.evidenceToggle.disabled = true;
+    elements.evidenceList.hidden = true;
+    elements.evidenceToggle.setAttribute("aria-expanded", "false");
+    elements.evidenceToggle.textContent = "Voir les indices";
+    return;
+  }
+  elements.evidenceToggle.disabled = false;
+  elements.evidenceList.hidden = true;
+  elements.evidenceToggle.textContent = "Voir les indices";
+  elements.evidenceToggle.setAttribute("aria-expanded", "false");
+  evidence.forEach((entry) => {
+    const item = document.createElement("li");
+    item.textContent = entry;
+    elements.evidenceList.appendChild(item);
+  });
+}
+function renderJson(elements, payload) {
+  elements.jsonOutput.textContent = JSON.stringify(payload, null, 2);
+}
+function renderSummary(elements, result) {
+  elements.summaryList.innerHTML = "";
+  result.summary.items.forEach((item) => {
+    const listItem = document.createElement("li");
+    const strong = document.createElement("strong");
+    strong.textContent = item.label;
+    listItem.appendChild(strong);
+    const textNode = document.createElement("span");
+    textNode.textContent = item.value;
+    listItem.appendChild(textNode);
+    elements.summaryList.appendChild(listItem);
+  });
+}
+function updateBadge(activeTabId, text) {
+  if (activeTabId === null) {
+    return;
+  }
+  chrome.action.setBadgeBackgroundColor({ tabId: activeTabId, color: "#0f766e" });
+  chrome.action.setBadgeText({ tabId: activeTabId, text });
+}
+function toggleEvidence(elements) {
+  const isHidden = elements.evidenceList.hidden;
+  if (isHidden) {
+    elements.evidenceList.hidden = false;
+    elements.evidenceToggle.textContent = "Masquer les indices";
+    elements.evidenceToggle.setAttribute("aria-expanded", "true");
+  } else {
+    elements.evidenceList.hidden = true;
+    elements.evidenceToggle.textContent = "Voir les indices";
+    elements.evidenceToggle.setAttribute("aria-expanded", "false");
   }
 }
+function renderCopyFeedback(elements, message) {
+  elements.copyFeedback.textContent = message;
+}
+function syncTour(elements, index) {
+  elements.tourSteps.forEach((step, position) => {
+    step.hidden = position !== index;
+  });
+  elements.tourPrev.disabled = index === 0;
+  elements.tourNext.textContent = index === elements.tourSteps.length - 1 ? "Terminer" : "Suivant";
+}
 
+// src/popup/status.ts
+function formatStatus(result) {
+  if (!result) {
+    return { emoji: "\u{1F7E1}", text: "Pr\xEAt \xE0 analyser." };
+  }
+  if (result.kind === "detail") {
+    const count = result.offersCount || 1;
+    return { emoji: "\u2705", text: `D\xE9tail d\xE9tect\xE9 (${count} offre)` };
+  }
+  if (result.kind === "list") {
+    const count = result.offersCount || 0;
+    return { emoji: "\u2705", text: `Liste d\xE9tect\xE9e : ${count} offre${count > 1 ? "s" : ""}` };
+  }
+  if (result.kind === "out_of_scope") {
+    return { emoji: "\u26D4", text: "Page hors p\xE9rim\xE8tre FreeWork" };
+  }
+  if (result.kind === "pending") {
+    return { emoji: "\u23F3", text: "Contenu en cours de chargement, r\xE9essayez." };
+  }
+  if (result.kind === "none") {
+    const reason = result.reason ? ` \u2014 ${capitalizeFirst(result.reason)}` : "";
+    return { emoji: "\u26A0\uFE0F", text: `Aucune offre d\xE9tectable${reason}` };
+  }
+  return { emoji: "\u26A0\uFE0F", text: "Aucune offre d\xE9tectable." };
+}
+function capitalizeFirst(text) {
+  if (!text) {
+    return "";
+  }
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+// src/popup/state.ts
+var state = {
+  activeTabId: null,
+  currentResult: null,
+  isAnalyzing: false,
+  retryTimeoutId: null,
+  isFreeWorkTab: false,
+  tourIndex: 0
+};
+function getState() {
+  return state;
+}
+function setActiveTab(tabId) {
+  state.activeTabId = tabId;
+}
+function setFreeWorkTab(value) {
+  state.isFreeWorkTab = value;
+}
+function setAnalyzing(value) {
+  state.isAnalyzing = value;
+}
+function setCurrentResult(result) {
+  state.currentResult = result;
+}
+function scheduleRetry(callback, delayMs) {
+  clearRetry();
+  state.retryTimeoutId = setTimeout(callback, delayMs);
+}
+function clearRetry() {
+  if (state.retryTimeoutId) {
+    clearTimeout(state.retryTimeoutId);
+    state.retryTimeoutId = null;
+  }
+}
+function setTourIndex(value) {
+  state.tourIndex = value;
+}
+
+// src/popup/actions.ts
+var MESSAGE_TYPE = "FREELANCEFINDER_ANALYZE";
+var MAX_RETRY_ATTEMPTS = 3;
+var RETRY_DELAY_MS = 1200;
+var COPY_FEEDBACK_TIMEOUT_MS = 2e3;
+async function setupPopup(elements) {
+  registerEventListeners(elements);
+  await initialize(elements);
+}
+function registerEventListeners(elements) {
+  elements.analyzeButton.addEventListener("click", () => handleAnalyze(elements));
+  elements.resetButton.addEventListener("click", () => handleReset(elements));
+  elements.copyButton.addEventListener("click", () => handleCopy(elements));
+  elements.evidenceToggle.addEventListener("click", () => toggleEvidence(elements));
+  elements.openTourButton.addEventListener("click", () => openTour(elements));
+  elements.tourPrev.addEventListener("click", () => previousTourStep(elements));
+  elements.tourNext.addEventListener("click", () => nextTourStep(elements));
+  elements.tourClose.addEventListener("click", () => elements.tourDialog.close());
+  elements.tourDialog.addEventListener("cancel", () => elements.tourDialog.close());
+}
+async function initialize(elements) {
+  const tab = await getActiveTab();
+  if (!tab) {
+    setStatus(elements, { emoji: "\u26A0\uFE0F", text: "Onglet actif introuvable." });
+    elements.analyzeButton.disabled = true;
+    elements.resetButton.disabled = false;
+    return;
+  }
+  setActiveTab(tab.id ?? null);
+  const url = tab.url ?? "";
+  const isFreeWorkTab = isFreeWorkUrl(url);
+  setFreeWorkTab(isFreeWorkTab);
+  if (!isFreeWorkTab) {
+    setStatus(elements, { emoji: "\u26D4", text: "Page hors p\xE9rim\xE8tre FreeWork" });
+    elements.analyzeButton.disabled = true;
+    elements.resetButton.disabled = false;
+    return;
+  }
+  setStatus(elements, { emoji: "\u{1F7E1}", text: "Pr\xEAt \xE0 analyser cette page FreeWork." });
+  elements.analyzeButton.disabled = false;
+}
+function handleAnalyze(elements) {
+  const state2 = getState();
+  if (state2.isAnalyzing || state2.activeTabId === null) {
+    return;
+  }
+  clearRetry();
+  setAnalyzing(true);
+  setStatus(elements, { emoji: "\u{1F50D}", text: "Analyse en cours\u2026" });
+  elements.resetButton.disabled = false;
+  elements.analyzeButton.disabled = true;
+  requestAnalysis(elements, 1);
+}
+function requestAnalysis(elements, attempt) {
+  const state2 = getState();
+  if (state2.activeTabId === null) {
+    finalizeAnalysis(elements, { kind: "none", reason: "onglet inactif", evidence: [] });
+    return;
+  }
+  sendMessage(state2.activeTabId, { type: MESSAGE_TYPE }).then((response) => {
+    if (!response) {
+      throw new Error("no_response");
+    }
+    if (response.kind === "pending" && attempt < MAX_RETRY_ATTEMPTS) {
+      setStatus(elements, formatStatus(response));
+      scheduleRetry(() => requestAnalysis(elements, attempt + 1), RETRY_DELAY_MS);
+      return;
+    }
+    finalizeAnalysis(elements, response);
+  }).catch(() => {
+    setStatus(elements, { emoji: "\u26A0\uFE0F", text: "Aucune offre d\xE9tectable \u2014 contenu inaccessible." });
+    elements.analyzeButton.disabled = !getState().isFreeWorkTab;
+    setAnalyzing(false);
+  });
+}
+function finalizeAnalysis(elements, result) {
+  clearRetry();
+  setCurrentResult(result);
+  const statusInfo = formatStatus(result);
+  setStatus(elements, statusInfo);
+  const state2 = getState();
+  if (isSuccessResult(result)) {
+    renderSuccess(elements, result, state2.activeTabId);
+  } else {
+    elements.resetButton.disabled = false;
+    elements.resultSection.hidden = true;
+    elements.copyButton.disabled = true;
+    updateBadge(state2.activeTabId, "");
+  }
+  elements.analyzeButton.disabled = !state2.isFreeWorkTab;
+  setAnalyzing(false);
+}
+function handleReset(elements) {
+  clearRetry();
+  setCurrentResult(null);
+  resetView(elements, getState().activeTabId);
+  const state2 = getState();
+  if (state2.isFreeWorkTab) {
+    setStatus(elements, { emoji: "\u{1F7E1}", text: "Pr\xEAt \xE0 analyser cette page FreeWork." });
+    elements.analyzeButton.disabled = false;
+  } else {
+    setStatus(elements, { emoji: "\u26D4", text: "Page hors p\xE9rim\xE8tre FreeWork" });
+    elements.analyzeButton.disabled = true;
+  }
+  setAnalyzing(false);
+}
+function handleCopy(elements) {
+  const state2 = getState();
+  if (!isSuccessResult(state2.currentResult)) {
+    return;
+  }
+  const jsonString = JSON.stringify(state2.currentResult.rawJson, null, 2);
+  navigator.clipboard.writeText(jsonString).then(() => {
+    renderCopyFeedback(elements, "JSON copi\xE9 dans le presse-papier.");
+    setTimeout(() => renderCopyFeedback(elements, ""), COPY_FEEDBACK_TIMEOUT_MS);
+  }).catch(() => {
+    renderCopyFeedback(elements, "Impossible de copier automatiquement.");
+  });
+}
+function openTour(elements) {
+  setTourIndex(0);
+  syncTour(elements, 0);
+  if (typeof elements.tourDialog.showModal === "function") {
+    elements.tourDialog.showModal();
+  }
+}
+function nextTourStep(elements) {
+  const state2 = getState();
+  const lastIndex = elements.tourSteps.length - 1;
+  if (state2.tourIndex < lastIndex) {
+    const nextIndex = state2.tourIndex + 1;
+    setTourIndex(nextIndex);
+    syncTour(elements, nextIndex);
+    return;
+  }
+  elements.tourDialog.close();
+}
+function previousTourStep(elements) {
+  const state2 = getState();
+  if (state2.tourIndex === 0) {
+    return;
+  }
+  const previousIndex = state2.tourIndex - 1;
+  setTourIndex(previousIndex);
+  syncTour(elements, previousIndex);
+}
+function isFreeWorkUrl(url) {
+  if (!url) {
+    return false;
+  }
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname.endsWith("free-work.com");
+  } catch (error) {
+    return false;
+  }
+}
 async function getActiveTab() {
   const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   if (tabs && tabs.length > 0) {
@@ -63,289 +358,31 @@ async function getActiveTab() {
   }
   return null;
 }
-
-function isFreeWorkUrl(url) {
-  try {
-    const { hostname } = new URL(url);
-    return hostname.endsWith('free-work.com');
-  } catch (error) {
-    return false;
-  }
-}
-
-function renderSummary(summary) {
-  summaryList.innerHTML = '';
-  if (!summary || !Array.isArray(summary.items)) {
-    return;
-  }
-
-  summary.items.forEach((item) => {
-    const listItem = document.createElement('li');
-    const strong = document.createElement('strong');
-    strong.textContent = item.label;
-    listItem.appendChild(strong);
-    const textNode = document.createElement('span');
-    textNode.textContent = item.value;
-    listItem.appendChild(textNode);
-    summaryList.appendChild(listItem);
-  });
-}
-
-function renderEvidence(evidence) {
-  evidenceList.innerHTML = '';
-  if (!Array.isArray(evidence) || evidence.length === 0) {
-    evidenceToggle.disabled = true;
-    evidenceList.hidden = true;
-    return;
-  }
-
-  evidenceToggle.disabled = false;
-  evidence.forEach((entry) => {
-    const item = document.createElement('li');
-    item.textContent = entry;
-    evidenceList.appendChild(item);
-  });
-}
-
-function formatStatus(result) {
-  if (!result) {
-    return { emoji: '🟡', text: 'Prêt à analyser.' };
-  }
-
-  if (result.kind === 'detail') {
-    const count = result.offersCount || 1;
-    return { emoji: '✅', text: `Détail détecté (${count} offre)` };
-  }
-
-  if (result.kind === 'list') {
-    const count = result.offersCount || 0;
-    return { emoji: '✅', text: `Liste détectée : ${count} offre${count > 1 ? 's' : ''}` };
-  }
-
-  if (result.kind === 'out_of_scope') {
-    return { emoji: '⛔', text: 'Page hors périmètre FreeWork' };
-  }
-
-  if (result.kind === 'pending') {
-    return { emoji: '⏳', text: 'Contenu en cours de chargement, réessayez.' };
-  }
-
-  if (result.kind === 'none') {
-    const reason = result.reason ? ` — ${capitalizeFirst(result.reason)}` : '';
-    return { emoji: '⚠️', text: `Aucune offre détectable${reason}` };
-  }
-
-  return { emoji: '⚠️', text: 'Aucune offre détectable.' };
-}
-
-function capitalizeFirst(text) {
-  if (!text) {
-    return '';
-  }
-  return text.charAt(0).toUpperCase() + text.slice(1);
-}
-
-function showResult(result) {
-  currentResult = result;
-  resultSection.hidden = false;
-  renderSummary(result.summary);
-  renderEvidence(result.evidence);
-  jsonOutput.textContent = JSON.stringify(result.rawJson, null, 2);
-  copyButton.disabled = false;
-  resetButton.disabled = false;
-  evidenceToggle.setAttribute('aria-expanded', 'false');
-  evidenceList.hidden = true;
-
-  const badgeText = result.offersCount && result.offersCount > 0 ? String(result.offersCount) : '';
-  if (activeTabId !== null) {
-    chrome.action.setBadgeBackgroundColor({ tabId: activeTabId, color: '#0f766e' });
-    chrome.action.setBadgeText({ tabId: activeTabId, text: badgeText });
-  }
-}
-
-async function requestAnalysis(attempt = 1) {
-  if (activeTabId === null) {
-    return;
-  }
-
-  try {
-    const response = await chrome.tabs.sendMessage(activeTabId, { type: 'FREELANCEFINDER_ANALYZE' });
-
-    if (!response) {
-      throw new Error('no_response');
-    }
-
-    if (response.kind === 'pending' && attempt < 3) {
-      const statusInfo = formatStatus(response);
-      setStatus(statusInfo.emoji, statusInfo.text);
-      retryTimeout = setTimeout(() => {
-        requestAnalysis(attempt + 1);
-      }, 1200);
-      return;
-    }
-
-    finalizeAnalysis(response);
-  } catch (error) {
-    const statusInfo = { emoji: '⚠️', text: "Aucune offre détectable — contenu inaccessible." };
-    setStatus(statusInfo.emoji, statusInfo.text);
-    enableAnalysis();
-    isAnalyzing = false;
-  }
-}
-
-function finalizeAnalysis(result) {
-  const statusInfo = formatStatus(result);
-  setStatus(statusInfo.emoji, statusInfo.text);
-
-  if (result.kind === 'detail' || result.kind === 'list') {
-    showResult(result);
-  } else {
-    resetButton.disabled = false;
-    resultSection.hidden = true;
-    if (activeTabId !== null) {
-      chrome.action.setBadgeText({ tabId: activeTabId, text: '' });
-    }
-  }
-
-  enableAnalysis();
-  isAnalyzing = false;
-}
-
-function handleAnalyze() {
-  if (isAnalyzing) {
-    return;
-  }
-
-  if (retryTimeout) {
-    clearTimeout(retryTimeout);
-    retryTimeout = null;
-  }
-
-  isAnalyzing = true;
-  setStatus('🔍', 'Analyse en cours…');
-  enableResetDuringAnalysis();
-  disableAnalysis();
-  requestAnalysis();
-}
-
-function enableResetDuringAnalysis() {
-  resetButton.disabled = false;
-}
-
-function handleReset() {
-  if (retryTimeout) {
-    clearTimeout(retryTimeout);
-    retryTimeout = null;
-  }
-  resetUiState();
-  if (isFreeWorkTab) {
-    setStatus('🟡', 'Prêt à analyser une page FreeWork.');
-  } else {
-    setStatus('⛔', 'Page hors périmètre FreeWork');
-  }
-  enableAnalysis();
-  isAnalyzing = false;
-}
-
-async function init() {
-  const tab = await getActiveTab();
-
-  if (!tab) {
-    setStatus('⚠️', 'Onglet actif introuvable.');
-    disableAnalysis();
-    return;
-  }
-
-  activeTabId = tab.id;
-  isFreeWorkTab = isFreeWorkUrl(tab.url || '');
-
-  if (!isFreeWorkTab) {
-    setStatus('⛔', 'Page hors périmètre FreeWork');
-    disableAnalysis();
-    resetButton.disabled = false;
-    return;
-  }
-
-  setStatus('🟡', 'Prêt à analyser cette page FreeWork.');
-  enableAnalysis();
-}
-
-function handleCopy() {
-  if (!currentResult) {
-    return;
-  }
-
-  const jsonString = JSON.stringify(currentResult.rawJson, null, 2);
-  navigator.clipboard
-    .writeText(jsonString)
-    .then(() => {
-      copyFeedback.textContent = 'JSON copié dans le presse-papier.';
-      setTimeout(() => {
-        copyFeedback.textContent = '';
-      }, 2000);
-    })
-    .catch(() => {
-      copyFeedback.textContent = 'Impossible de copier automatiquement.';
+function sendMessage(tabId, payload) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, payload, (response) => {
+      const lastError = chrome.runtime.lastError;
+      if (lastError) {
+        reject(new Error(lastError.message));
+        return;
+      }
+      resolve(response);
     });
-}
-
-function toggleEvidence() {
-  const isHidden = evidenceList.hidden;
-  if (isHidden) {
-    evidenceList.hidden = false;
-    evidenceToggle.textContent = 'Masquer les indices';
-    evidenceToggle.setAttribute('aria-expanded', 'true');
-  } else {
-    evidenceList.hidden = true;
-    evidenceToggle.textContent = 'Voir les indices';
-    evidenceToggle.setAttribute('aria-expanded', 'false');
-  }
-}
-
-function openTour() {
-  tourIndex = 0;
-  syncTour();
-  if (typeof tourDialog.showModal === 'function') {
-    tourDialog.showModal();
-  }
-}
-
-function syncTour() {
-  tourSteps.forEach((step, index) => {
-    step.hidden = index !== tourIndex;
   });
-  tourPrev.disabled = tourIndex === 0;
-  tourNext.textContent = tourIndex === tourSteps.length - 1 ? 'Terminer' : 'Suivant';
+}
+function isSuccessResult(result) {
+  return result !== null && (result.kind === "detail" || result.kind === "list");
 }
 
-function nextTourStep() {
-  if (tourIndex < tourSteps.length - 1) {
-    tourIndex += 1;
-    syncTour();
-    return;
+// src/popup/popup.ts
+async function bootstrap() {
+  try {
+    const elements = getElements();
+    await setupPopup(elements);
+  } catch (error) {
+    console.error("popup_init_failed", error);
   }
-  tourDialog.close();
 }
-
-function previousTourStep() {
-  if (tourIndex === 0) {
-    return;
-  }
-  tourIndex -= 1;
-  syncTour();
-}
-
-openTourButton.addEventListener('click', openTour);
-analyzeButton.addEventListener('click', handleAnalyze);
-resetButton.addEventListener('click', handleReset);
-copyButton.addEventListener('click', handleCopy);
-evidenceToggle.addEventListener('click', toggleEvidence);
-tourPrev.addEventListener('click', previousTourStep);
-tourNext.addEventListener('click', nextTourStep);
-tourClose.addEventListener('click', () => tourDialog.close());
-tourDialog.addEventListener('cancel', () => tourDialog.close());
-
-document.addEventListener('DOMContentLoaded', () => {
-  init();
+document.addEventListener("DOMContentLoaded", () => {
+  void bootstrap();
 });
-

--- a/apps/extension-demo/src/content-script.ts
+++ b/apps/extension-demo/src/content-script.ts
@@ -1,0 +1,35 @@
+import { mapDetectionOutcome } from "./lib/result-mapper";
+import type { AnalysisResponse } from "./lib/messages";
+import { loadDetector } from "./lib/detector-loader";
+
+const MESSAGE_TYPE = "FREELANCEFINDER_ANALYZE";
+
+/**
+ * Transforme le document courant en réponse structurée pour la popup.
+ * Les erreurs sont remontées au caller pour être traduites en message utilisateur.
+ */
+async function analyzeCurrentDocument(): Promise<AnalysisResponse> {
+  const url = window.location.href;
+  const detect = await loadDetector();
+  const outcome = await detect(document, { url });
+  const context = { url, detectedAt: new Date().toISOString() };
+  return mapDetectionOutcome(outcome, context);
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!message || message.type !== MESSAGE_TYPE) {
+    return;
+  }
+
+  analyzeCurrentDocument()
+    .then((result) => sendResponse(result))
+    .catch(() => {
+      sendResponse({
+        kind: "none",
+        reason: "erreur inattendue",
+        evidence: ["Une erreur interne a interrompu la détection."],
+      });
+    });
+
+  return true;
+});

--- a/apps/extension-demo/src/detector-entry.ts
+++ b/apps/extension-demo/src/detector-entry.ts
@@ -1,0 +1,1 @@
+export { detectFreeWorkOffers } from "#detectors/freework";

--- a/apps/extension-demo/src/lib/detector-loader.test.ts
+++ b/apps/extension-demo/src/lib/detector-loader.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { detectFreeWorkOffers } from "#detectors/freework";
+import { configureDetectorImporter, loadDetector, resetDetectorCache, type DetectorImporter } from "./detector-loader";
+
+type DetectFn = typeof detectFreeWorkOffers;
+
+describe("detector-loader", () => {
+  beforeEach(() => {
+    resetDetectorCache();
+  });
+
+  afterEach(() => {
+    configureDetectorImporter();
+    resetDetectorCache();
+  });
+
+  it("loads the detector once and reuses the cached instance", async () => {
+    const detector = vi.fn<Parameters<DetectFn>, ReturnType<DetectFn>>();
+    const importer = vi
+      .fn<Parameters<DetectorImporter>, ReturnType<DetectorImporter>>()
+      .mockResolvedValue({ detectFreeWorkOffers: detector });
+
+    configureDetectorImporter(importer);
+    const first = await loadDetector();
+    const second = await loadDetector();
+
+    expect(first).toBe(detector);
+    expect(second).toBe(detector);
+    expect(importer).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries when the module import fails", async () => {
+    const detector = vi.fn<Parameters<DetectFn>, ReturnType<DetectFn>>();
+    const importer = vi
+      .fn<Parameters<DetectorImporter>, ReturnType<DetectorImporter>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ detectFreeWorkOffers: detector });
+
+    configureDetectorImporter(importer);
+    await expect(loadDetector()).rejects.toThrow("boom");
+
+    const loaded = await loadDetector();
+    expect(loaded).toBe(detector);
+    expect(importer).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a clear error when the detector export is missing", async () => {
+    const emptyImporter: DetectorImporter = () => Promise.resolve({});
+    configureDetectorImporter(emptyImporter);
+    await expect(loadDetector()).rejects.toThrow("detector_export_missing");
+  });
+});

--- a/apps/extension-demo/src/lib/detector-loader.ts
+++ b/apps/extension-demo/src/lib/detector-loader.ts
@@ -1,0 +1,50 @@
+import type { detectFreeWorkOffers } from "#detectors/freework";
+
+type DetectFn = typeof detectFreeWorkOffers;
+type DetectorModule = { detectFreeWorkOffers?: DetectFn };
+
+export type DetectorImporter = () => Promise<DetectorModule>;
+
+let detectorPromise: Promise<DetectFn> | null = null;
+let importer: DetectorImporter = defaultImporter;
+
+/**
+ * Charge dynamiquement le détecteur FreeWork et garantit un cache cohérent.
+ * L'import dynamique est isolé ici afin de pouvoir être testé et résilient.
+ */
+export async function loadDetector(): Promise<DetectFn> {
+  if (!detectorPromise) {
+    detectorPromise = importer().then(validateModule);
+  }
+
+  try {
+    return await detectorPromise;
+  } catch (error) {
+    detectorPromise = null;
+    throw error;
+  }
+}
+
+export function configureDetectorImporter(customImporter?: DetectorImporter): void {
+  importer = customImporter ?? defaultImporter;
+  detectorPromise = null;
+}
+
+export function resetDetectorCache(): void {
+  detectorPromise = null;
+}
+
+function validateModule(module: DetectorModule): DetectFn {
+  if (typeof module.detectFreeWorkOffers !== "function") {
+    throw new Error("detector_export_missing");
+  }
+  return module.detectFreeWorkOffers;
+}
+
+function defaultImporter(): Promise<DetectorModule> {
+  const runtime = globalThis.chrome?.runtime;
+  if (!runtime || typeof runtime.getURL !== "function") {
+    throw new Error("chrome_runtime_unavailable");
+  }
+  return import(runtime.getURL("detector.js"));
+}

--- a/apps/extension-demo/src/lib/evidence-format.ts
+++ b/apps/extension-demo/src/lib/evidence-format.ts
@@ -1,0 +1,16 @@
+import type { JobOffer } from "@freelancefinder/types";
+
+export function flattenEvidence(offers: JobOffer[]): string[] {
+  const collected: string[] = [];
+  offers.forEach((offer, index) => {
+    const prefix = offers.length > 1 ? `${index + 1}. ` : "";
+    offer.evidence.forEach((entry) => {
+      collected.push(`${prefix}${formatLabel(entry.label)} — ${entry.snippet}`);
+    });
+  });
+  return collected;
+}
+
+function formatLabel(label: string): string {
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}

--- a/apps/extension-demo/src/lib/messages.ts
+++ b/apps/extension-demo/src/lib/messages.ts
@@ -1,0 +1,56 @@
+import type { OfferDetectionOutcome, JobOffer } from "@freelancefinder/types";
+
+export interface SummaryItem {
+  label: string;
+  value: string;
+}
+
+export interface Summary {
+  items: SummaryItem[];
+}
+
+export type AnalysisSuccessKind = "detail" | "list";
+
+export interface AnalysisSuccessResult {
+  kind: AnalysisSuccessKind;
+  offersCount: number;
+  summary: Summary;
+  rawJson: Record<string, unknown>;
+  evidence: string[];
+}
+
+export interface AnalysisPendingResult {
+  kind: "pending";
+  reason: string;
+  evidence: string[];
+}
+
+export interface AnalysisNoneResult {
+  kind: "none";
+  reason?: string;
+  evidence: string[];
+}
+
+export interface AnalysisOutOfScopeResult {
+  kind: "out_of_scope";
+  evidence: string[];
+}
+
+export type AnalysisResponse =
+  | AnalysisSuccessResult
+  | AnalysisPendingResult
+  | AnalysisNoneResult
+  | AnalysisOutOfScopeResult;
+
+export interface DetectionMappingContext {
+  url: string;
+  detectedAt: string;
+}
+
+export interface EvidenceFormatter {
+  (offers: JobOffer[]): string[];
+}
+
+export interface SummaryBuilder {
+  (pageType: OfferDetectionOutcome["pageType"], offers: JobOffer[]): Summary;
+}

--- a/apps/extension-demo/src/lib/offer-summary.ts
+++ b/apps/extension-demo/src/lib/offer-summary.ts
@@ -1,0 +1,58 @@
+import type { JobOffer, OfferDetectionOutcome } from "@freelancefinder/types";
+import type { Summary, SummaryItem } from "./messages";
+
+const LIST_PREVIEW_LIMIT = 3;
+const STACK_PREVIEW_LIMIT = 6;
+
+export function buildSummary(pageType: OfferDetectionOutcome["pageType"], offers: JobOffer[]): Summary {
+  if (pageType === "detail" && offers[0]) {
+    return { items: buildDetailSummary(offers[0]) };
+  }
+  return { items: buildListSummary(offers.slice(0, LIST_PREVIEW_LIMIT)) };
+}
+
+function buildDetailSummary(offer: JobOffer): SummaryItem[] {
+  const items: SummaryItem[] = [];
+  if (offer.title) {
+    items.push({ label: "Titre", value: offer.title });
+  }
+  const location = formatLocation(offer);
+  if (location) {
+    items.push({ label: "Lieu / Remote", value: location });
+  }
+  if (offer.contractType) {
+    items.push({ label: "Contrat", value: offer.contractType });
+  }
+  if (offer.rate?.raw) {
+    items.push({ label: "Taux", value: offer.rate.raw });
+  }
+  if (offer.stack.length > 0) {
+    items.push({ label: "Stack", value: offer.stack.slice(0, STACK_PREVIEW_LIMIT).join(" · ") });
+  }
+  return items;
+}
+
+function buildListSummary(offers: JobOffer[]): SummaryItem[] {
+  return offers.map((offer, index) => {
+    const parts = [offer.title, formatLocation(offer), offer.rate?.raw].filter(Boolean) as string[];
+    const value = parts.join(" — ") || "Offre détectée";
+    return { label: `${index + 1}.`, value };
+  });
+}
+
+function formatLocation(offer: JobOffer): string | undefined {
+  const parts: string[] = [];
+  if (offer.location) {
+    parts.push(offer.location);
+  }
+  if (offer.isRemote) {
+    const policy = offer.remotePolicy ?? "Remote";
+    if (!parts.some((part) => part.toLowerCase().includes("remote"))) {
+      parts.push(policy);
+    }
+  }
+  if (parts.length === 0) {
+    return undefined;
+  }
+  return parts.join(" — ");
+}

--- a/apps/extension-demo/src/lib/result-mapper.test.ts
+++ b/apps/extension-demo/src/lib/result-mapper.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { mapDetectionOutcome } from "./result-mapper";
+import type { OfferDetectionOutcome } from "@freelancefinder/types";
+import type { AnalysisResponse, AnalysisSuccessResult, AnalysisPendingResult } from "./messages";
+
+const context = { url: "https://www.free-work.com/test", detectedAt: "2024-01-01T00:00:00.000Z" };
+
+describe("result mapper", () => {
+  it("maps successful detail outcome", () => {
+    const outcome: OfferDetectionOutcome = {
+      status: "ok",
+      message: "Offre détectée (détail)",
+      pageType: "detail",
+      offers: [
+        {
+          source: "FreeWork",
+          url: "https://www.free-work.com/job",
+          title: "Développeur",
+          stack: ["Node.js"],
+          tags: ["Node.js"],
+          confidence: 0.9,
+          evidence: [{ label: "title", snippet: "Développeur" }],
+        },
+      ],
+    };
+
+    const result = mapDetectionOutcome(outcome, context);
+    assertSuccess(result);
+    expect(result.kind).toBe("detail");
+    expect(result.offersCount).toBe(1);
+    expect(result.summary.items[0]).toEqual({ label: "Titre", value: "Développeur" });
+    expect(result.evidence).toContain("Title — Développeur");
+  });
+
+  it("maps delayed outcome to pending", () => {
+    const outcome: OfferDetectionOutcome = {
+      status: "content_delayed",
+      message: "Aucune offre détectable (contenu tardif)",
+      pageType: "unknown",
+      offers: [],
+      diagnostics: { reason: "contenu tardif" },
+    };
+
+    const result = mapDetectionOutcome(outcome, context);
+    assertPending(result);
+    expect(result.reason).toBe("contenu tardif");
+  });
+
+  it("maps out_of_scope outcome", () => {
+    const outcome: OfferDetectionOutcome = {
+      status: "out_of_scope",
+      message: "Page hors périmètre FreeWork",
+      pageType: "unknown",
+      offers: [],
+    };
+
+    const result = mapDetectionOutcome(outcome, context);
+    expect(result.kind).toBe("out_of_scope");
+    expect(result.evidence[0]).toContain(context.url);
+  });
+});
+
+function assertSuccess(result: AnalysisResponse): asserts result is AnalysisSuccessResult {
+  if (result.kind !== "detail" && result.kind !== "list") {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+}
+
+function assertPending(result: AnalysisResponse): asserts result is AnalysisPendingResult {
+  if (result.kind !== "pending") {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+}

--- a/apps/extension-demo/src/lib/result-mapper.ts
+++ b/apps/extension-demo/src/lib/result-mapper.ts
@@ -1,0 +1,53 @@
+import type { OfferDetectionOutcome } from "@freelancefinder/types";
+import { buildSummary } from "./offer-summary";
+import { flattenEvidence } from "./evidence-format";
+import type { AnalysisResponse, DetectionMappingContext } from "./messages";
+
+export function mapDetectionOutcome(
+  outcome: OfferDetectionOutcome,
+  context: DetectionMappingContext,
+): AnalysisResponse {
+  if (outcome.status === "out_of_scope") {
+    return {
+      kind: "out_of_scope",
+      evidence: [`URL analysée : ${context.url}`],
+    };
+  }
+
+  if (outcome.status === "ok") {
+    const summary = buildSummary(outcome.pageType, outcome.offers);
+    const evidence = flattenEvidence(outcome.offers);
+    const rawJson = {
+      url: context.url,
+      detectedAt: context.detectedAt,
+      status: outcome.status,
+      pageType: outcome.pageType,
+      offers: outcome.offers,
+      diagnostics: outcome.diagnostics,
+      evidence,
+      source: "detector",
+    };
+    return {
+      kind: outcome.pageType === "detail" ? "detail" : "list",
+      offersCount: outcome.offers.length,
+      summary,
+      rawJson,
+      evidence,
+    };
+  }
+
+  const reason = outcome.diagnostics?.reason;
+  if (outcome.status === "content_delayed") {
+    return {
+      kind: "pending",
+      reason: reason ?? "contenu tardif",
+      evidence: ["Contenu encore en chargement détecté par le moteur FreeWork."],
+    };
+  }
+
+  return {
+    kind: "none",
+    reason,
+    evidence: reason ? [`Motif : ${reason}.`] : [],
+  };
+}

--- a/apps/extension-demo/src/popup/actions.ts
+++ b/apps/extension-demo/src/popup/actions.ts
@@ -1,0 +1,225 @@
+import type { AnalysisResponse, AnalysisSuccessResult } from "../lib/messages";
+import type { PopupElements } from "./dom";
+import { setStatus, resetView, renderSuccess, renderCopyFeedback, toggleEvidence, syncTour, updateBadge } from "./render";
+import { formatStatus } from "./status";
+import {
+  getState,
+  setActiveTab,
+  setAnalyzing,
+  setCurrentResult,
+  scheduleRetry,
+  clearRetry,
+  setFreeWorkTab,
+  setTourIndex,
+} from "./state";
+
+const MESSAGE_TYPE = "FREELANCEFINDER_ANALYZE";
+const MAX_RETRY_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 1200;
+const COPY_FEEDBACK_TIMEOUT_MS = 2000;
+
+export async function setupPopup(elements: PopupElements): Promise<void> {
+  registerEventListeners(elements);
+  await initialize(elements);
+}
+
+function registerEventListeners(elements: PopupElements): void {
+  elements.analyzeButton.addEventListener("click", () => handleAnalyze(elements));
+  elements.resetButton.addEventListener("click", () => handleReset(elements));
+  elements.copyButton.addEventListener("click", () => handleCopy(elements));
+  elements.evidenceToggle.addEventListener("click", () => toggleEvidence(elements));
+  elements.openTourButton.addEventListener("click", () => openTour(elements));
+  elements.tourPrev.addEventListener("click", () => previousTourStep(elements));
+  elements.tourNext.addEventListener("click", () => nextTourStep(elements));
+  elements.tourClose.addEventListener("click", () => elements.tourDialog.close());
+  elements.tourDialog.addEventListener("cancel", () => elements.tourDialog.close());
+}
+
+async function initialize(elements: PopupElements): Promise<void> {
+  const tab = await getActiveTab();
+  if (!tab) {
+    setStatus(elements, { emoji: "⚠️", text: "Onglet actif introuvable." });
+    elements.analyzeButton.disabled = true;
+    elements.resetButton.disabled = false;
+    return;
+  }
+
+  setActiveTab(tab.id ?? null);
+  const url = tab.url ?? "";
+  const isFreeWorkTab = isFreeWorkUrl(url);
+  setFreeWorkTab(isFreeWorkTab);
+
+  if (!isFreeWorkTab) {
+    setStatus(elements, { emoji: "⛔", text: "Page hors périmètre FreeWork" });
+    elements.analyzeButton.disabled = true;
+    elements.resetButton.disabled = false;
+    return;
+  }
+
+  setStatus(elements, { emoji: "🟡", text: "Prêt à analyser cette page FreeWork." });
+  elements.analyzeButton.disabled = false;
+}
+
+function handleAnalyze(elements: PopupElements): void {
+  const state = getState();
+  if (state.isAnalyzing || state.activeTabId === null) {
+    return;
+  }
+
+  clearRetry();
+  setAnalyzing(true);
+  setStatus(elements, { emoji: "🔍", text: "Analyse en cours…" });
+  elements.resetButton.disabled = false;
+  elements.analyzeButton.disabled = true;
+  requestAnalysis(elements, 1);
+}
+
+function requestAnalysis(elements: PopupElements, attempt: number): void {
+  const state = getState();
+  if (state.activeTabId === null) {
+    finalizeAnalysis(elements, { kind: "none", reason: "onglet inactif", evidence: [] });
+    return;
+  }
+
+  sendMessage<AnalysisResponse>(state.activeTabId, { type: MESSAGE_TYPE })
+    .then((response) => {
+      if (!response) {
+        throw new Error("no_response");
+      }
+
+      if (response.kind === "pending" && attempt < MAX_RETRY_ATTEMPTS) {
+        setStatus(elements, formatStatus(response));
+        scheduleRetry(() => requestAnalysis(elements, attempt + 1), RETRY_DELAY_MS);
+        return;
+      }
+
+      finalizeAnalysis(elements, response);
+    })
+    .catch(() => {
+      setStatus(elements, { emoji: "⚠️", text: "Aucune offre détectable — contenu inaccessible." });
+      elements.analyzeButton.disabled = !getState().isFreeWorkTab;
+      setAnalyzing(false);
+    });
+}
+
+function finalizeAnalysis(elements: PopupElements, result: AnalysisResponse): void {
+  clearRetry();
+  setCurrentResult(result);
+  const statusInfo = formatStatus(result);
+  setStatus(elements, statusInfo);
+
+  const state = getState();
+  if (isSuccessResult(result)) {
+    renderSuccess(elements, result, state.activeTabId);
+  } else {
+    elements.resetButton.disabled = false;
+    elements.resultSection.hidden = true;
+    elements.copyButton.disabled = true;
+    updateBadge(state.activeTabId, "");
+  }
+
+  elements.analyzeButton.disabled = !state.isFreeWorkTab;
+  setAnalyzing(false);
+}
+
+function handleReset(elements: PopupElements): void {
+  clearRetry();
+  setCurrentResult(null);
+  resetView(elements, getState().activeTabId);
+
+  const state = getState();
+  if (state.isFreeWorkTab) {
+    setStatus(elements, { emoji: "🟡", text: "Prêt à analyser cette page FreeWork." });
+    elements.analyzeButton.disabled = false;
+  } else {
+    setStatus(elements, { emoji: "⛔", text: "Page hors périmètre FreeWork" });
+    elements.analyzeButton.disabled = true;
+  }
+
+  setAnalyzing(false);
+}
+
+function handleCopy(elements: PopupElements): void {
+  const state = getState();
+  if (!isSuccessResult(state.currentResult)) {
+    return;
+  }
+
+  const jsonString = JSON.stringify(state.currentResult.rawJson, null, 2);
+  navigator.clipboard
+    .writeText(jsonString)
+    .then(() => {
+      renderCopyFeedback(elements, "JSON copié dans le presse-papier.");
+      setTimeout(() => renderCopyFeedback(elements, ""), COPY_FEEDBACK_TIMEOUT_MS);
+    })
+    .catch(() => {
+      renderCopyFeedback(elements, "Impossible de copier automatiquement.");
+    });
+}
+
+function openTour(elements: PopupElements): void {
+  setTourIndex(0);
+  syncTour(elements, 0);
+  if (typeof elements.tourDialog.showModal === "function") {
+    elements.tourDialog.showModal();
+  }
+}
+
+function nextTourStep(elements: PopupElements): void {
+  const state = getState();
+  const lastIndex = elements.tourSteps.length - 1;
+  if (state.tourIndex < lastIndex) {
+    const nextIndex = state.tourIndex + 1;
+    setTourIndex(nextIndex);
+    syncTour(elements, nextIndex);
+    return;
+  }
+  elements.tourDialog.close();
+}
+
+function previousTourStep(elements: PopupElements): void {
+  const state = getState();
+  if (state.tourIndex === 0) {
+    return;
+  }
+  const previousIndex = state.tourIndex - 1;
+  setTourIndex(previousIndex);
+  syncTour(elements, previousIndex);
+}
+
+function isFreeWorkUrl(url: string | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname.endsWith("free-work.com");
+  } catch (error) {
+    return false;
+  }
+}
+
+async function getActiveTab(): Promise<chrome.tabs.Tab | null> {
+  const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  if (tabs && tabs.length > 0) {
+    return tabs[0];
+  }
+  return null;
+}
+
+function sendMessage<T>(tabId: number, payload: unknown): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, payload, (response) => {
+      const lastError = chrome.runtime.lastError;
+      if (lastError) {
+        reject(new Error(lastError.message));
+        return;
+      }
+      resolve(response as T);
+    });
+  });
+}
+
+function isSuccessResult(result: AnalysisResponse | null): result is AnalysisSuccessResult {
+  return result !== null && (result.kind === "detail" || result.kind === "list");
+}

--- a/apps/extension-demo/src/popup/dom.ts
+++ b/apps/extension-demo/src/popup/dom.ts
@@ -1,0 +1,54 @@
+export interface PopupElements {
+  statusContainer: HTMLElement;
+  statusEmoji: HTMLElement;
+  statusText: HTMLElement;
+  analyzeButton: HTMLButtonElement;
+  resetButton: HTMLButtonElement;
+  copyButton: HTMLButtonElement;
+  copyFeedback: HTMLElement;
+  resultSection: HTMLElement;
+  summaryList: HTMLUListElement;
+  jsonOutput: HTMLElement;
+  jsonPanel: HTMLDetailsElement;
+  evidenceToggle: HTMLButtonElement;
+  evidenceList: HTMLUListElement;
+  openTourButton: HTMLButtonElement;
+  tourDialog: HTMLDialogElement;
+  tourSteps: HTMLElement[];
+  tourPrev: HTMLButtonElement;
+  tourNext: HTMLButtonElement;
+  tourClose: HTMLButtonElement;
+}
+
+export function getElements(): PopupElements {
+  const statusContainer = requireElement<HTMLElement>(document.getElementById("status"));
+  const statusEmojiElement = statusContainer.querySelector<HTMLElement>(".status-emoji");
+  return {
+    statusContainer,
+    statusEmoji: requireElement<HTMLElement>(statusEmojiElement),
+    statusText: requireElement<HTMLElement>(document.getElementById("status-text")),
+    analyzeButton: requireElement<HTMLButtonElement>(document.getElementById("analyze") as HTMLButtonElement),
+    resetButton: requireElement<HTMLButtonElement>(document.getElementById("reset") as HTMLButtonElement),
+    copyButton: requireElement<HTMLButtonElement>(document.getElementById("copy") as HTMLButtonElement),
+    copyFeedback: requireElement<HTMLElement>(document.getElementById("copy-feedback")),
+    resultSection: requireElement<HTMLElement>(document.getElementById("result")),
+    summaryList: requireElement<HTMLUListElement>(document.getElementById("summary") as HTMLUListElement),
+    jsonOutput: requireElement<HTMLElement>(document.getElementById("json-output")),
+    jsonPanel: requireElement<HTMLDetailsElement>(document.getElementById("json-panel") as HTMLDetailsElement),
+    evidenceToggle: requireElement<HTMLButtonElement>(document.getElementById("toggle-evidence") as HTMLButtonElement),
+    evidenceList: requireElement<HTMLUListElement>(document.getElementById("evidence-list") as HTMLUListElement),
+    openTourButton: requireElement<HTMLButtonElement>(document.getElementById("open-tour") as HTMLButtonElement),
+    tourDialog: requireElement<HTMLDialogElement>(document.getElementById("tour") as HTMLDialogElement),
+    tourSteps: Array.from(document.querySelectorAll<HTMLElement>(".tour-step")),
+    tourPrev: requireElement<HTMLButtonElement>(document.getElementById("tour-prev") as HTMLButtonElement),
+    tourNext: requireElement<HTMLButtonElement>(document.getElementById("tour-next") as HTMLButtonElement),
+    tourClose: requireElement<HTMLButtonElement>(document.getElementById("tour-close") as HTMLButtonElement),
+  };
+}
+
+function requireElement<T extends Element>(value: T | null | undefined): T {
+  if (!value) {
+    throw new Error("popup_element_missing");
+  }
+  return value;
+}

--- a/apps/extension-demo/src/popup/popup.ts
+++ b/apps/extension-demo/src/popup/popup.ts
@@ -1,0 +1,15 @@
+import { getElements } from "./dom";
+import { setupPopup } from "./actions";
+
+async function bootstrap() {
+  try {
+    const elements = getElements();
+    await setupPopup(elements);
+  } catch (error) {
+    console.error("popup_init_failed", error);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  void bootstrap();
+});

--- a/apps/extension-demo/src/popup/render.ts
+++ b/apps/extension-demo/src/popup/render.ts
@@ -1,0 +1,110 @@
+import type { AnalysisSuccessResult } from "../lib/messages";
+import type { PopupElements } from "./dom";
+import type { StatusInfo } from "./status";
+
+export function setStatus(elements: PopupElements, info: StatusInfo): void {
+  elements.statusEmoji.textContent = info.emoji;
+  elements.statusText.textContent = info.text;
+}
+
+export function resetView(elements: PopupElements, activeTabId: number | null): void {
+  elements.resultSection.hidden = true;
+  elements.summaryList.innerHTML = "";
+  elements.jsonOutput.textContent = "";
+  elements.jsonPanel.open = false;
+  elements.copyButton.disabled = true;
+  elements.evidenceToggle.disabled = true;
+  elements.evidenceToggle.setAttribute("aria-expanded", "false");
+  elements.evidenceToggle.textContent = "Voir les indices";
+  elements.evidenceList.hidden = true;
+  elements.evidenceList.innerHTML = "";
+  elements.copyFeedback.textContent = "";
+  elements.resetButton.disabled = true;
+  updateBadge(activeTabId, "");
+}
+
+export function renderSuccess(
+  elements: PopupElements,
+  result: AnalysisSuccessResult,
+  activeTabId: number | null,
+): void {
+  elements.resultSection.hidden = false;
+  elements.resetButton.disabled = false;
+  elements.copyButton.disabled = false;
+  renderSummary(elements, result);
+  renderEvidence(elements, result.evidence);
+  renderJson(elements, result.rawJson);
+  updateBadge(activeTabId, result.offersCount > 0 ? String(result.offersCount) : "");
+}
+
+export function renderEvidence(elements: PopupElements, evidence: string[]): void {
+  elements.evidenceList.innerHTML = "";
+  if (evidence.length === 0) {
+    elements.evidenceToggle.disabled = true;
+    elements.evidenceList.hidden = true;
+    elements.evidenceToggle.setAttribute("aria-expanded", "false");
+    elements.evidenceToggle.textContent = "Voir les indices";
+    return;
+  }
+
+  elements.evidenceToggle.disabled = false;
+  elements.evidenceList.hidden = true;
+  elements.evidenceToggle.textContent = "Voir les indices";
+  elements.evidenceToggle.setAttribute("aria-expanded", "false");
+  evidence.forEach((entry) => {
+    const item = document.createElement("li");
+    item.textContent = entry;
+    elements.evidenceList.appendChild(item);
+  });
+}
+
+export function renderJson(elements: PopupElements, payload: Record<string, unknown>): void {
+  elements.jsonOutput.textContent = JSON.stringify(payload, null, 2);
+}
+
+export function renderSummary(elements: PopupElements, result: AnalysisSuccessResult): void {
+  elements.summaryList.innerHTML = "";
+  result.summary.items.forEach((item) => {
+    const listItem = document.createElement("li");
+    const strong = document.createElement("strong");
+    strong.textContent = item.label;
+    listItem.appendChild(strong);
+    const textNode = document.createElement("span");
+    textNode.textContent = item.value;
+    listItem.appendChild(textNode);
+    elements.summaryList.appendChild(listItem);
+  });
+}
+
+export function updateBadge(activeTabId: number | null, text: string): void {
+  if (activeTabId === null) {
+    return;
+  }
+  chrome.action.setBadgeBackgroundColor({ tabId: activeTabId, color: "#0f766e" });
+  chrome.action.setBadgeText({ tabId: activeTabId, text });
+}
+
+export function toggleEvidence(elements: PopupElements): void {
+  const isHidden = elements.evidenceList.hidden;
+  if (isHidden) {
+    elements.evidenceList.hidden = false;
+    elements.evidenceToggle.textContent = "Masquer les indices";
+    elements.evidenceToggle.setAttribute("aria-expanded", "true");
+  } else {
+    elements.evidenceList.hidden = true;
+    elements.evidenceToggle.textContent = "Voir les indices";
+    elements.evidenceToggle.setAttribute("aria-expanded", "false");
+  }
+}
+
+export function renderCopyFeedback(elements: PopupElements, message: string): void {
+  elements.copyFeedback.textContent = message;
+}
+
+export function syncTour(elements: PopupElements, index: number): void {
+  elements.tourSteps.forEach((step, position) => {
+    step.hidden = position !== index;
+  });
+  elements.tourPrev.disabled = index === 0;
+  elements.tourNext.textContent = index === elements.tourSteps.length - 1 ? "Terminer" : "Suivant";
+}

--- a/apps/extension-demo/src/popup/state.ts
+++ b/apps/extension-demo/src/popup/state.ts
@@ -1,0 +1,55 @@
+import type { AnalysisResponse } from "../lib/messages";
+
+export interface PopupState {
+  activeTabId: number | null;
+  currentResult: AnalysisResponse | null;
+  isAnalyzing: boolean;
+  retryTimeoutId: ReturnType<typeof setTimeout> | null;
+  isFreeWorkTab: boolean;
+  tourIndex: number;
+}
+
+const state: PopupState = {
+  activeTabId: null,
+  currentResult: null,
+  isAnalyzing: false,
+  retryTimeoutId: null,
+  isFreeWorkTab: false,
+  tourIndex: 0,
+};
+
+export function getState(): PopupState {
+  return state;
+}
+
+export function setActiveTab(tabId: number | null): void {
+  state.activeTabId = tabId;
+}
+
+export function setFreeWorkTab(value: boolean): void {
+  state.isFreeWorkTab = value;
+}
+
+export function setAnalyzing(value: boolean): void {
+  state.isAnalyzing = value;
+}
+
+export function setCurrentResult(result: AnalysisResponse | null): void {
+  state.currentResult = result;
+}
+
+export function scheduleRetry(callback: () => void, delayMs: number): void {
+  clearRetry();
+  state.retryTimeoutId = setTimeout(callback, delayMs);
+}
+
+export function clearRetry(): void {
+  if (state.retryTimeoutId) {
+    clearTimeout(state.retryTimeoutId);
+    state.retryTimeoutId = null;
+  }
+}
+
+export function setTourIndex(value: number): void {
+  state.tourIndex = value;
+}

--- a/apps/extension-demo/src/popup/status.ts
+++ b/apps/extension-demo/src/popup/status.ts
@@ -1,0 +1,44 @@
+import type { AnalysisResponse } from "../lib/messages";
+
+export interface StatusInfo {
+  emoji: string;
+  text: string;
+}
+
+export function formatStatus(result: AnalysisResponse | null): StatusInfo {
+  if (!result) {
+    return { emoji: "🟡", text: "Prêt à analyser." };
+  }
+
+  if (result.kind === "detail") {
+    const count = result.offersCount || 1;
+    return { emoji: "✅", text: `Détail détecté (${count} offre)` };
+  }
+
+  if (result.kind === "list") {
+    const count = result.offersCount || 0;
+    return { emoji: "✅", text: `Liste détectée : ${count} offre${count > 1 ? "s" : ""}` };
+  }
+
+  if (result.kind === "out_of_scope") {
+    return { emoji: "⛔", text: "Page hors périmètre FreeWork" };
+  }
+
+  if (result.kind === "pending") {
+    return { emoji: "⏳", text: "Contenu en cours de chargement, réessayez." };
+  }
+
+  if (result.kind === "none") {
+    const reason = result.reason ? ` — ${capitalizeFirst(result.reason)}` : "";
+    return { emoji: "⚠️", text: `Aucune offre détectable${reason}` };
+  }
+
+  return { emoji: "⚠️", text: "Aucune offre détectable." };
+}
+
+function capitalizeFirst(text: string): string {
+  if (!text) {
+    return "";
+  }
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}

--- a/apps/extension-demo/tsconfig.json
+++ b/apps/extension-demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@freelancefinder/config/tsconfig/base.json",
+  "compilerOptions": {
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "types": ["chrome"],
+    "module": "ESNext",
+    "target": "ES2021",
+    "moduleResolution": "Node",
+    "allowJs": false,
+    "baseUrl": ".",
+    "paths": {
+      "#detectors/*": ["../../packages/detectors/src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/extension-demo/tsup.config.ts
+++ b/apps/extension-demo/tsup.config.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+import { defineConfig } from "tsup";
+import aliasPlugin from "esbuild-plugin-alias";
+
+export default defineConfig({
+  entry: ["src/content-script.ts", "src/popup/popup.ts", "src/detector-entry.ts"],
+  format: "esm",
+  target: "es2022",
+  outDir: "dist",
+  clean: true,
+  platform: "browser",
+  splitting: false,
+  sourcemap: false,
+  treeshake: true,
+  noExternal: [/.*/],
+  esbuildPlugins: [
+    aliasPlugin({
+      "#detectors/freework": path.resolve(
+        __dirname,
+        "../../packages/detectors/src/freework/detector.ts",
+      ),
+      "#detectors/url": path.resolve(
+        __dirname,
+        "../../packages/detectors/src/utils/url.ts",
+      ),
+    }),
+  ],
+});

--- a/packages/detectors/src/freework/detail.ts
+++ b/packages/detectors/src/freework/detail.ts
@@ -1,0 +1,193 @@
+import type { JobOffer } from "../types";
+import { findMainHeading } from "../parsing/heading";
+import { collectMetaTexts, findByLabel, findExperience, findPostedAt } from "../parsing/meta";
+import { findContractType } from "../parsing/contract";
+import type { RemoteInfo } from "../normalize/remote";
+import { detectRemote } from "../normalize/remote";
+import { findLocation } from "../normalize/location";
+import { looksLikeRate, parseRate } from "../normalize/rate";
+import { normalizeText } from "../normalize/text";
+import { collectTags } from "../parsing/tags";
+import { extractCompany } from "../parsing/company";
+import { extractDescription } from "../parsing/description";
+import { detectTechnologiesFromTexts } from "../parsing/technologies";
+import { populateEvidence } from "../state/evidence";
+import type { EvidenceParts } from "../state/evidence";
+import { computeConfidence } from "../state/confidence";
+
+interface DetailMetaData {
+  texts: string[];
+  rateText?: string;
+  contractType?: string;
+  rate?: JobOffer["rate"];
+  location?: string;
+  remote: RemoteInfo;
+  startDate?: string;
+  duration?: string;
+  experienceLevel?: string;
+  postedAt?: string;
+}
+
+export interface DetailExtractionResult {
+  offer: JobOffer | null;
+  ready: boolean;
+  reason?: string;
+}
+
+/**
+ * Construit une offre détaillée à partir du DOM d'une page annonce FreeWork.
+ * Retourne également un indicateur de complétude pour guider le polling.
+ */
+export function extractDetailOffer(document: Document, pageUrl: URL): DetailExtractionResult {
+  const main = resolveDetailRoot(document);
+  if (!main) {
+    return { offer: null, ready: false, reason: "structure introuvable" };
+  }
+
+  const heading = findMainHeading(main);
+  const title = heading ? normalizeText(heading.textContent) : "";
+  if (!isValidTitle(title)) {
+    return { offer: null, ready: false, reason: "titre absent" };
+  }
+
+  const metaData = buildMetaData(main);
+  const description = extractDescription(main);
+  const tags = collectTags(main);
+  const stack = buildStack(metaData.texts, description, tags);
+
+  const offer = assembleOffer({
+    pageUrl,
+    title,
+    company: extractCompany(main),
+    description,
+    tags,
+    stack,
+    metaData,
+  });
+
+  applyConfidence(offer, stack.length, description?.length ?? 0, metaData);
+  populateEvidence(offer, heading, buildEvidence(metaData, description, tags));
+
+  const readiness = evaluateReadiness(stack.length, description?.length ?? 0, metaData);
+  return { offer, ready: readiness.ready, reason: readiness.reason };
+}
+
+function resolveDetailRoot(document: Document): Element | null {
+  return document.querySelector("main") ?? document.body;
+}
+
+function isValidTitle(value: string | undefined): value is string {
+  return Boolean(value && value.trim().length >= 6);
+}
+
+function buildMetaData(main: Element): DetailMetaData {
+  const texts = collectMetaTexts(main);
+  const rateText = texts.find(looksLikeRate);
+  const rate = rateText ? parseRate(rateText) : undefined;
+  const contractType = findContractType(texts);
+
+  let location = findLocation(texts, { includeRemote: false });
+  const remote = detectRemote([...texts, location ?? ""]);
+  if (!location && remote.snippet) {
+    location = remote.snippet;
+  }
+
+  return {
+    texts,
+    rateText,
+    rate,
+    contractType,
+    location,
+    remote,
+    startDate: findByLabel(texts, /(d[eé]marrage|d[eé]but|start)/i),
+    duration: findByLabel(texts, /dur[eé]e/i),
+    experienceLevel: findExperience(texts),
+    postedAt: findPostedAt(texts),
+  };
+}
+
+function buildStack(metaTexts: string[], description: string | undefined, tags: string[]): string[] {
+  const stackSet = new Set<string>(tags);
+  detectTechnologiesFromTexts([...metaTexts, description ?? ""], stackSet);
+  return Array.from(stackSet);
+}
+
+interface AssembleOfferParams {
+  pageUrl: URL;
+  title: string;
+  company: string | undefined;
+  description: string | undefined;
+  tags: string[];
+  stack: string[];
+  metaData: DetailMetaData;
+}
+
+function assembleOffer(params: AssembleOfferParams): JobOffer {
+  const { pageUrl, title, company, description, tags, stack, metaData } = params;
+  return {
+    source: "FreeWork",
+    url: pageUrl.toString(),
+    title,
+    company,
+    location: metaData.location,
+    isRemote: metaData.remote.isRemote,
+    remotePolicy: metaData.remote.policy,
+    contractType: metaData.contractType,
+    rate: metaData.rate,
+    startDate: metaData.startDate,
+    duration: metaData.duration,
+    experienceLevel: metaData.experienceLevel,
+    stack,
+    description,
+    postedAt: metaData.postedAt,
+    tags,
+    confidence: 0,
+    evidence: [],
+  };
+}
+
+function applyConfidence(
+  offer: JobOffer,
+  stackCount: number,
+  descriptionLength: number,
+  metaData: DetailMetaData,
+): void {
+  offer.confidence = computeConfidence({
+    hasTitle: Boolean(offer.title),
+    hasRate: Boolean(metaData.rate),
+    hasLocationOrRemote: Boolean(metaData.location || metaData.remote.isRemote),
+    stackCount,
+    descriptionLength,
+    hasContract: Boolean(metaData.contractType),
+  });
+}
+
+function buildEvidence(metaData: DetailMetaData, description: string | undefined, tags: string[]): EvidenceParts {
+  return {
+    rateText: metaData.rateText,
+    location: metaData.location,
+    contractType: metaData.contractType,
+    startDate: metaData.startDate,
+    duration: metaData.duration,
+    experienceLevel: metaData.experienceLevel,
+    postedAt: metaData.postedAt,
+    remoteSnippet: metaData.remote.snippet,
+    descriptionSnippet: description,
+    tags,
+  };
+}
+
+function evaluateReadiness(
+  stackCount: number,
+  descriptionLength: number,
+  metaData: DetailMetaData,
+): { ready: boolean; reason?: string } {
+  const essentialSignals = [
+    Boolean(metaData.rate),
+    Boolean(metaData.location || metaData.remote.isRemote),
+    stackCount >= 2,
+    descriptionLength >= 150,
+  ];
+  const ready = essentialSignals.filter(Boolean).length >= 2 && descriptionLength >= 120;
+  return ready ? { ready } : { ready: false, reason: "informations partielles" };
+}

--- a/packages/detectors/src/freework/detector.test.ts
+++ b/packages/detectors/src/freework/detector.test.ts
@@ -201,4 +201,18 @@ describe("detectFreeWorkOffers", () => {
     expect(result.message).toMatch(/Aucune offre détectable/i);
     expect(result.diagnostics?.reason).toBeDefined();
   });
+
+  it("reports content_delayed when structure is still loading", async () => {
+    const doc = createDom(`<div class="placeholder">Chargement…</div>`, detailUrl);
+
+    const result = await detectFreeWorkOffers(doc, {
+      url: detailUrl,
+      maxWaitMs: 20,
+      pollIntervalMs: 10,
+    });
+
+    expect(result.status).toBe("content_delayed");
+    expect(result.message).toMatch(/contenu tardif/i);
+    expect(result.diagnostics?.reason).toBe("contenu tardif");
+  });
 });

--- a/packages/detectors/src/freework/detector.ts
+++ b/packages/detectors/src/freework/detector.ts
@@ -1,200 +1,133 @@
-import type {
-  DetectionOptions,
-  DetectionPageType,
-  NormalizedRate,
-  OfferDetectionItem,
-  OfferDetectionOutcome,
-  OfferEvidence,
-} from "@freelancefinder/types";
-
+import type { DetectionOptions, DetectionPageType, JobOffer, OfferDetectionOutcome } from "../types";
 export type {
   DetectionOptions,
   DetectionPageType,
-  NormalizedRate,
-  OfferDetectionItem,
+  JobOffer,
   OfferDetectionOutcome,
   OfferEvidence,
-} from "@freelancefinder/types";
+  OfferDetectionItem,
+  NormalizedRate,
+} from "../types";
 
-const FREEWORK_HOST_SUFFIX = "free-work.com";
-const DEFAULT_MAX_WAIT_MS = 180;
+import { pollUntil } from "../state/poller";
+import type { PollOutcome } from "../state/poller";
+import { safeParseUrl, isFreeWorkDomain } from "../utils/url";
+import { extractDetailOffer } from "./detail";
+import { extractListOffers } from "./list";
+import { findMainHeading } from "../parsing/heading";
+import { normalizeText } from "../normalize/text";
+
+const DEFAULT_MAX_WAIT_MS = 1_800;
 const DEFAULT_POLL_INTERVAL_MS = 40;
 
-const REMOTE_KEYWORDS = [
-  /full\s*remote/i,
-  /remote/i,
-  /télétravail/i,
-  /teletravail/i,
-  /hybride/i,
-  /home\s*office/i,
-];
+interface PollingConfig {
+  maxWaitMs: number;
+  pollIntervalMs: number;
+}
 
-const CONTRACT_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
-  { pattern: /freelance/i, label: "Freelance" },
-  { pattern: /cdi/i, label: "CDI" },
-  { pattern: /cdd/i, label: "CDD" },
-  { pattern: /portage/i, label: "Portage" },
-  { pattern: /stage/i, label: "Stage" },
-  { pattern: /alternance/i, label: "Alternance" },
-];
-
-const LOCATION_KEYWORDS = [
-  "paris",
-  "lyon",
-  "marseille",
-  "toulouse",
-  "bordeaux",
-  "nantes",
-  "lille",
-  "rennes",
-  "grenoble",
-  "strasbourg",
-  "montpellier",
-  "nice",
-  "sophia",
-  "niort",
-  "brest",
-  "dijon",
-  "tours",
-  "angers",
-  "rouen",
-  "saint",
-  "télétravail",
-  "remote",
-  "hybride",
-  "france",
-  "idf",
-];
-
-const TECHNOLOGY_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
-  { label: "Node.js", pattern: /node\.?js/i },
-  { label: "React", pattern: /react/i },
-  { label: "TypeScript", pattern: /typescript|ts\b/i },
-  { label: "JavaScript", pattern: /javascript/i },
-  { label: "AWS", pattern: /\baws\b/i },
-  { label: "Azure", pattern: /azure/i },
-  { label: "GCP", pattern: /\bgoogle cloud|\bgcp\b/i },
-  { label: "Kubernetes", pattern: /kubernetes|k8s/i },
-  { label: "Docker", pattern: /docker/i },
-  { label: "Terraform", pattern: /terraform/i },
-  { label: "Java", pattern: /\bjava\b/i },
-  { label: "Spring", pattern: /spring\b/i },
-  { label: "Python", pattern: /python/i },
-  { label: "Django", pattern: /django/i },
-  { label: "Flask", pattern: /flask/i },
-  { label: "PHP", pattern: /\bphp\b/i },
-  { label: "Symfony", pattern: /symfony/i },
-  { label: "Laravel", pattern: /laravel/i },
-  { label: "Go", pattern: /\bgo\b|golang/i },
-  { label: "Rust", pattern: /rust/i },
-  { label: "C#", pattern: /c#/i },
-  { label: "C++", pattern: /c\+\+/i },
-  { label: "Ruby", pattern: /ruby/i },
-  { label: "Rails", pattern: /rails/i },
-  { label: "Scala", pattern: /scala/i },
-  { label: "Swift", pattern: /swift/i },
-  { label: "Kotlin", pattern: /kotlin/i },
-  { label: "Android", pattern: /android/i },
-  { label: "iOS", pattern: /\bios\b/i },
-  { label: "Angular", pattern: /angular/i },
-  { label: "Vue", pattern: /vue\.js|vuejs|\bvue\b/i },
-  { label: "Svelte", pattern: /svelte/i },
-  { label: "GraphQL", pattern: /graphql/i },
-  { label: "PostgreSQL", pattern: /postgresql|postgres/i },
-  { label: "MySQL", pattern: /mysql/i },
-  { label: "MongoDB", pattern: /mongodb/i },
-  { label: "Redis", pattern: /redis/i },
-  { label: "Kafka", pattern: /kafka/i },
-  { label: "Spark", pattern: /spark/i },
-  { label: "Hadoop", pattern: /hadoop/i },
-  { label: "Elasticsearch", pattern: /elasticsearch|elastic/i },
-];
-
-interface AnalysisResult {
+interface AnalysisSnapshot {
   pageType: DetectionPageType;
-  offers: OfferDetectionItem[];
+  offers: JobOffer[];
+  ready: boolean;
   message?: string;
   reason?: string;
 }
 
-interface DetailExtractionResult {
-  offer: OfferDetectionItem | null;
-  ready: boolean;
-  reason?: string;
-}
-
+/**
+ * Analyse un document FreeWork et renvoie l'issue consolidée pour l'extension.
+ * La fonction ne change pas les messages visibles : elle se limite à orchestrer
+ * la boucle d'attente et la transformation des résultats intermédiaires.
+ */
 export async function detectFreeWorkOffers(
   document: Document,
   options: DetectionOptions,
 ): Promise<OfferDetectionOutcome> {
-  const parsedUrl = safeParseUrl(options.url);
+  const pageUrl = ensureFreeWorkUrl(options.url);
+  if (!pageUrl) {
+    return buildOutOfScopeOutcome();
+  }
+
+  const pollingConfig = resolvePollingConfig(options);
+  const pollResult = await pollUntil(
+    options,
+    pollingConfig,
+    () => analyseDocument(document, pageUrl),
+    isSuccessfulAnalysis,
+  );
+
+  return finalizeOutcome(pollResult.value, pollResult);
+}
+
+function ensureFreeWorkUrl(rawUrl: string): URL | null {
+  const parsedUrl = safeParseUrl(rawUrl);
   if (!parsedUrl || !isFreeWorkDomain(parsedUrl)) {
+    return null;
+  }
+  return parsedUrl;
+}
+
+function resolvePollingConfig(options: DetectionOptions): PollingConfig {
+  return {
+    maxWaitMs: options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS,
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+  };
+}
+
+function isSuccessfulAnalysis(analysis: AnalysisSnapshot): boolean {
+  return analysis.ready && analysis.offers.length > 0;
+}
+
+function buildOutOfScopeOutcome(): OfferDetectionOutcome {
+  return {
+    status: "out_of_scope",
+    message: "Page hors périmètre FreeWork",
+    pageType: "unknown",
+    offers: [],
+  };
+}
+
+function finalizeOutcome(
+  analysis: AnalysisSnapshot,
+  pollResult: PollOutcome<AnalysisSnapshot>,
+): OfferDetectionOutcome {
+  if (analysis.offers.length > 0) {
     return {
-      status: "out_of_scope",
-      message: "Page hors périmètre FreeWork",
-      pageType: "unknown",
-      offers: [],
+      status: "ok",
+      message: analysis.message ?? buildSuccessMessage(analysis.pageType, analysis.offers.length),
+      pageType: analysis.pageType,
+      offers: analysis.offers,
+      diagnostics: {
+        attempts: pollResult.attempts,
+        waitedMs: pollResult.waitedMs,
+      },
     };
   }
 
-  const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
-  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  const start = currentTime(options);
-  const deadline = start + maxWaitMs;
-
-  let attempts = 0;
-  let analysis: AnalysisResult = { pageType: "unknown", offers: [], reason: "contenu insuffisant" };
-
-  for (let now = currentTime(options); now <= deadline; now = currentTime(options)) {
-    attempts += 1;
-    analysis = analyseDocument(document, parsedUrl);
-
-    if (analysis.offers.length > 0) {
-      const waitedMs = currentTime(options) - start;
-      return {
-        status: "ok",
-        message: analysis.message ?? buildSuccessMessage(analysis.pageType, analysis.offers.length),
-        pageType: analysis.pageType,
-        offers: analysis.offers,
-        diagnostics: {
-          attempts,
-          waitedMs,
-        },
-      };
-    }
-
-    if (now >= deadline) {
-      break;
-    }
-
-    const remaining = Math.max(0, deadline - now);
-    const waitDuration = Math.min(pollIntervalMs, remaining);
-    if (waitDuration > 0) {
-      await delay(waitDuration);
-    }
-  }
-
-  const finalElapsed = Math.max(0, currentTime(options) - start);
   const reason = analysis.reason ?? "contenu insuffisant";
+  const status = reason === "contenu tardif" ? "content_delayed" : "no_offers";
   return {
-    status: "no_offers",
+    status,
     message: `Aucune offre détectable (${reason})`,
     pageType: analysis.pageType,
     offers: [],
     diagnostics: {
-      attempts,
-      waitedMs: finalElapsed,
+      attempts: pollResult.attempts,
+      waitedMs: pollResult.waitedMs,
       reason,
     },
   };
 }
 
-function analyseDocument(document: Document, pageUrl: URL): AnalysisResult {
-  const detailExtraction = extractDetailOffer(document, pageUrl);
-  if (detailExtraction.offer && detailExtraction.ready) {
+/**
+ * Évalue la page courante et indique si une offre exploitable est prête.
+ */
+function analyseDocument(document: Document, pageUrl: URL): AnalysisSnapshot {
+  const detail = extractDetailOffer(document, pageUrl);
+  if (detail.offer && detail.ready) {
     return {
       pageType: "detail",
-      offers: [detailExtraction.offer],
+      offers: [detail.offer],
+      ready: true,
       message: "Offre détectée (détail)",
     };
   }
@@ -204,15 +137,17 @@ function analyseDocument(document: Document, pageUrl: URL): AnalysisResult {
     return {
       pageType: "list",
       offers: listOffers,
+      ready: true,
       message: `Liste détectée : ${listOffers.length} offres`,
     };
   }
 
-  if (detailExtraction.offer) {
+  if (detail.offer) {
     return {
       pageType: "detail",
       offers: [],
-      reason: detailExtraction.reason ?? "informations partielles",
+      ready: false,
+      reason: detail.reason ?? "informations partielles",
     };
   }
 
@@ -220,641 +155,21 @@ function analyseDocument(document: Document, pageUrl: URL): AnalysisResult {
     return {
       pageType: "list",
       offers: [],
+      ready: false,
       reason: "une seule carte détectée",
     };
   }
 
   const hasHeading = Boolean(findMainHeading(document));
+  const pageText = normalizeText(document.body?.textContent ?? "");
+  const hasLoadingKeyword = /chargement|loading|spinner|patientez/i.test(pageText);
+  const hasMeaningfulText = pageText.length >= 60 || (!hasLoadingKeyword && pageText.length >= 12);
   return {
     pageType: "unknown",
     offers: [],
-    reason: hasHeading ? "structure atypique" : "contenu tardif",
+    ready: false,
+    reason: hasHeading || hasMeaningfulText ? "structure atypique" : "contenu tardif",
   };
-}
-
-function extractDetailOffer(document: Document, pageUrl: URL): DetailExtractionResult {
-  const main = document.querySelector("main") ?? document.body;
-  if (!main) {
-    return { offer: null, ready: false, reason: "structure introuvable" };
-  }
-
-  const heading = findMainHeading(main);
-  const title = heading ? normalizeText(heading.textContent) : undefined;
-  if (!title || title.length < 6) {
-    return { offer: null, ready: false, reason: "titre absent" };
-  }
-
-  const metaTexts = collectMetaTexts(main);
-  const rateText = metaTexts.find(looksLikeRate);
-  const rate = rateText ? parseRate(rateText) : undefined;
-
-  const contractType = findContractType(metaTexts);
-  let location = findLocation(metaTexts, { includeRemote: false });
-  const remoteInfo = detectRemote([...metaTexts, location ?? ""]);
-  if (!location && remoteInfo.snippet) {
-    location = remoteInfo.snippet;
-  }
-
-  const startDate = findByLabel(metaTexts, /(d[eé]marrage|d[eé]but|start)/i);
-  const duration = findByLabel(metaTexts, /dur[eé]e/i);
-  const experienceLevel = findExperience(metaTexts);
-  const postedAt = findPostedAt(metaTexts);
-
-  const company = extractCompany(main);
-
-  const tags = collectTags(main);
-  const description = extractDescription(main);
-
-  const stackSet = new Set<string>(tags);
-  detectTechnologiesFromTexts([...metaTexts, description ?? ""], stackSet);
-
-  const stack = Array.from(stackSet);
-  const descriptionSnippet = description ? truncate(description, 900) : undefined;
-
-  const offer: OfferDetectionItem = {
-    source: "FreeWork",
-    url: pageUrl.toString(),
-    title,
-    company,
-    location,
-    isRemote: remoteInfo.isRemote,
-    remotePolicy: remoteInfo.policy,
-    contractType,
-    rate,
-    startDate,
-    duration,
-    experienceLevel,
-    stack,
-    description: descriptionSnippet,
-    postedAt,
-    tags,
-    confidence: 0,
-    evidence: [],
-  };
-
-  const descriptionLength = descriptionSnippet?.length ?? 0;
-  offer.confidence = computeConfidence({
-    hasTitle: Boolean(title),
-    hasRate: Boolean(rate),
-    hasLocationOrRemote: Boolean(location || remoteInfo.isRemote),
-    stackCount: stack.length,
-    descriptionLength,
-    hasContract: Boolean(contractType),
-  });
-
-  populateEvidence(offer, heading, {
-    rateText,
-    location,
-    contractType,
-    startDate,
-    duration,
-    experienceLevel,
-    postedAt,
-    remoteSnippet: remoteInfo.snippet,
-    descriptionSnippet,
-    tags,
-  });
-
-  const essentialSignals = [
-    Boolean(rate),
-    Boolean(location || remoteInfo.isRemote),
-    stack.length >= 2,
-    descriptionLength >= 150,
-  ];
-  const ready = essentialSignals.filter(Boolean).length >= 2 && descriptionLength >= 120;
-  const reason = ready ? undefined : "informations partielles";
-
-  return { offer, ready, reason };
-}
-
-function extractListOffers(document: Document, pageUrl: URL): OfferDetectionItem[] {
-  const anchors = Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href]"));
-  const cards: Array<{ root: Element; anchor: HTMLAnchorElement; title: string }> = [];
-  const seen = new Set<Element>();
-
-  for (const anchor of anchors) {
-    const href = anchor.getAttribute("href");
-    if (!href || !/\bjob\b/i.test(href)) {
-      continue;
-    }
-    const titleElement = anchor.querySelector("h1, h2, h3, h4, h5") ?? anchor;
-    const title = normalizeText(titleElement.textContent);
-    if (!title || title.length < 5 || /postuler/i.test(title)) {
-      continue;
-    }
-
-    const root = anchor.closest("article, li, section, div") ?? anchor;
-    if (seen.has(root)) {
-      continue;
-    }
-    seen.add(root);
-    cards.push({ root, anchor, title });
-  }
-
-  const offers: OfferDetectionItem[] = [];
-  for (const card of cards) {
-    const absoluteUrl = toAbsoluteUrl(card.anchor.getAttribute("href") ?? "", pageUrl);
-    if (!absoluteUrl) {
-      continue;
-    }
-
-    const cardText = normalizeText(card.root.textContent);
-    const segments = splitSegments(cardText);
-    const metaCandidates = collectMetaTexts(card.root);
-    const combinedSegments = uniqueStrings([...segments, ...metaCandidates]);
-
-    const rateText = combinedSegments.find(looksLikeRate);
-    const rate = rateText ? parseRate(rateText) : undefined;
-
-    let location = findLocation(combinedSegments, { includeRemote: true });
-    const remoteInfo = detectRemote(combinedSegments);
-    if (!location && remoteInfo.snippet) {
-      location = remoteInfo.snippet;
-    }
-
-    const stackSet = new Set<string>();
-    detectTechnologiesFromTexts([card.title, ...combinedSegments], stackSet);
-    const tags = collectTags(card.root);
-    for (const tag of tags) {
-      stackSet.add(tag);
-    }
-    const stack = Array.from(stackSet);
-
-    const snippet = buildCardSnippet(card.root, card.title);
-
-    const offer: OfferDetectionItem = {
-      source: "FreeWork",
-      url: absoluteUrl,
-      title: card.title,
-      location,
-      isRemote: remoteInfo.isRemote,
-      remotePolicy: remoteInfo.policy,
-      contractType: findContractType(combinedSegments),
-      rate,
-      stack,
-      description: snippet,
-      tags: uniqueStrings([...tags, ...stack]),
-      confidence: 0,
-      evidence: [],
-    };
-
-    offer.confidence = computeConfidence({
-      hasTitle: true,
-      hasRate: Boolean(rate),
-      hasLocationOrRemote: Boolean(location || remoteInfo.isRemote),
-      stackCount: stack.length,
-      descriptionLength: snippet.length,
-      hasContract: Boolean(offer.contractType),
-    });
-
-    populateEvidence(offer, card.anchor, {
-      rateText,
-      location,
-      contractType: offer.contractType,
-      descriptionSnippet: snippet,
-      remoteSnippet: remoteInfo.snippet,
-      tags: offer.tags,
-    });
-
-    offers.push(offer);
-  }
-
-  return offers;
-}
-
-function populateEvidence(
-  offer: OfferDetectionItem,
-  titleElement: Element | null,
-  parts: {
-    rateText?: string;
-    location?: string;
-    contractType?: string;
-    startDate?: string;
-    duration?: string;
-    experienceLevel?: string;
-    postedAt?: string;
-    remoteSnippet?: string;
-    descriptionSnippet?: string;
-    tags?: string[];
-  },
-) {
-  const evidence: OfferEvidence[] = [];
-  pushEvidence(evidence, "title", offer.title, titleElement ? buildSelector(titleElement) : undefined);
-  if (parts.rateText) {
-    pushEvidence(evidence, "rate", parts.rateText);
-  }
-  if (parts.location) {
-    pushEvidence(evidence, "location", parts.location);
-  }
-  if (offer.rate?.raw && !parts.rateText) {
-    pushEvidence(evidence, "rate", offer.rate.raw);
-  }
-  if (parts.contractType) {
-    pushEvidence(evidence, "contract", parts.contractType);
-  }
-  if (parts.startDate) {
-    pushEvidence(evidence, "startDate", parts.startDate);
-  }
-  if (parts.duration) {
-    pushEvidence(evidence, "duration", parts.duration);
-  }
-  if (parts.experienceLevel) {
-    pushEvidence(evidence, "experience", parts.experienceLevel);
-  }
-  if (parts.postedAt) {
-    pushEvidence(evidence, "postedAt", parts.postedAt);
-  }
-  if (parts.remoteSnippet) {
-    pushEvidence(evidence, "remote", parts.remoteSnippet);
-  }
-  if (parts.descriptionSnippet) {
-    pushEvidence(evidence, "description", truncate(parts.descriptionSnippet, 180));
-  }
-  if (parts.tags && parts.tags.length > 0) {
-    pushEvidence(evidence, "tags", parts.tags.slice(0, 3).join(", "));
-  }
-
-  if (evidence.length < 3 && offer.description) {
-    pushEvidence(evidence, "context", truncate(offer.description, 160));
-  }
-  if (evidence.length < 3 && offer.rate?.raw) {
-    pushEvidence(evidence, "pricing", offer.rate.raw);
-  }
-  if (evidence.length < 3 && offer.location) {
-    pushEvidence(evidence, "geo", offer.location);
-  }
-
-  offer.evidence = evidence;
-}
-
-function findMainHeading(root: ParentNode): Element | null {
-  const heading = root.querySelector("h1") ?? root.querySelector("h2");
-  return heading;
-}
-
-function collectMetaTexts(root: ParentNode): string[] {
-  const selectors = [
-    ".meta",
-    "[class*='meta']",
-    "[class*='info']",
-    "header",
-    "ul",
-    "dl",
-  ];
-  const collected = new Set<string>();
-  for (const selector of selectors) {
-    const elements = root instanceof Document ? root.querySelectorAll(selector) : root.querySelectorAll(selector);
-    for (const element of elements) {
-      for (const child of Array.from(element.querySelectorAll("span, div, li, dt, dd, p"))) {
-        const text = normalizeText(child.textContent);
-        if (!text) continue;
-        if (text.length > 140) continue;
-        collected.add(text);
-      }
-    }
-  }
-
-  if (root instanceof Element) {
-    const immediateSpans = Array.from(root.querySelectorAll("span, li, p"));
-    for (const span of immediateSpans) {
-      const text = normalizeText(span.textContent);
-      if (!text || text.length > 140) continue;
-      collected.add(text);
-    }
-  }
-
-  return Array.from(collected);
-}
-
-function findContractType(metaTexts: string[]): string | undefined {
-  for (const { pattern, label } of CONTRACT_PATTERNS) {
-    if (metaTexts.some((text) => pattern.test(text))) {
-      return label;
-    }
-  }
-  return undefined;
-}
-
-function detectRemote(texts: string[]): { isRemote: boolean; snippet?: string; policy?: string } {
-  for (const text of texts) {
-    if (!text) continue;
-    for (const pattern of REMOTE_KEYWORDS) {
-      if (pattern.test(text)) {
-        return { isRemote: true, snippet: text, policy: normalizeRemotePolicy(text) };
-      }
-    }
-  }
-  return { isRemote: false };
-}
-
-function normalizeRemotePolicy(text: string): string | undefined {
-  const normalized = text.toLowerCase();
-  if (normalized.includes("hybride")) {
-    return "hybrid";
-  }
-  if (normalized.includes("full")) {
-    return "full-remote";
-  }
-  if (normalized.includes("remote") || normalized.includes("télétravail") || normalized.includes("teletravail")) {
-    return "remote";
-  }
-  return undefined;
-}
-
-function findByLabel(metaTexts: string[], label: RegExp): string | undefined {
-  for (const text of metaTexts) {
-    const match = text.match(label);
-    if (match) {
-        const parts = text.split(/[:-]/);
-      if (parts.length > 1) {
-        return normalizeText(parts.slice(1).join(":"));
-      }
-      const after = text.slice(match.index ?? 0 + match[0].length).trim();
-      if (after) {
-        return normalizeText(after);
-      }
-      return text;
-    }
-  }
-  return undefined;
-}
-
-function findExperience(metaTexts: string[]): string | undefined {
-  for (const text of metaTexts) {
-    if (/exp[eé]rience/i.test(text) || /junior/i.test(text) || /senior/i.test(text) || /\b\d+\s*(ans|years)/i.test(text)) {
-      return text;
-    }
-  }
-  return undefined;
-}
-
-function findPostedAt(metaTexts: string[]): string | undefined {
-  for (const text of metaTexts) {
-    if (/publi[eé]e?/i.test(text) || /post[eé]e?/i.test(text) || /il y a/i.test(text)) {
-      return text;
-    }
-  }
-  return undefined;
-}
-
-function findLocation(metaTexts: string[], options: { includeRemote: boolean }): string | undefined {
-  for (const text of metaTexts) {
-    if (!text) continue;
-    if (!options.includeRemote && REMOTE_KEYWORDS.some((pattern) => pattern.test(text))) {
-      continue;
-    }
-    if (looksLikeRate(text) || /dur[eé]e/i.test(text) || /d[eé]marrage/i.test(text) || /exp[eé]rience/i.test(text)) {
-      continue;
-    }
-    const lower = text.toLowerCase();
-    if (/freelance|cdi|cdd|stage|alternance|portage/.test(lower)) {
-      continue;
-    }
-    if (LOCATION_KEYWORDS.some((keyword) => lower.includes(keyword))) {
-      return text;
-    }
-    if (/\d{5}/.test(text) && /[A-Za-z]/.test(text)) {
-      return text;
-    }
-    const words = lower.split(/[,•-]/).map((part) => part.trim());
-    for (const word of words) {
-      if (word.length >= 3 && /^[a-zéèêàùâûç\s]+$/.test(word) && word.split(" ").length <= 3) {
-        if (!looksLikeRate(word) && !/exp[eé]rience|dur[eé]e|d[eé]marrage/.test(word)) {
-          return text;
-        }
-      }
-    }
-  }
-  return undefined;
-}
-
-function collectTags(root: ParentNode): string[] {
-  const selectors = [".tag", "[class*='tag']", "[class*='skill']", "[class*='stack']", "[data-tag]"];
-  const tags = new Set<string>();
-  for (const selector of selectors) {
-    const elements = root instanceof Document ? root.querySelectorAll(selector) : root.querySelectorAll(selector);
-    for (const element of elements) {
-      const text = normalizeText(element.textContent);
-      if (!text || text.length > 40) continue;
-      const className = element.getAttribute("class")?.toLowerCase() ?? "";
-      const classes = className.split(/\s+/);
-      if (classes.some((cls) => cls === "tags" || cls === "tags-list" || cls === "tag-list")) {
-        continue;
-      }
-      if (element.childElementCount > 0) {
-        const hasTagChild = Array.from(element.children).some((child) => {
-          const childClass = child.getAttribute("class")?.toLowerCase() ?? "";
-          return childClass.includes("tag");
-        });
-        if (hasTagChild) {
-          continue;
-        }
-      }
-      if (/^tag$/i.test(text)) continue;
-      tags.add(text);
-    }
-  }
-  return Array.from(tags);
-}
-
-function extractCompany(root: ParentNode): string | undefined {
-  const headings = Array.from(root.querySelectorAll("h2, h3, strong"));
-  for (const heading of headings) {
-    const text = normalizeText(heading.textContent);
-    if (!text) continue;
-    if (/soci[eé]t[eé]|entreprise|client/i.test(text)) {
-      const nextText = normalizeText(getFollowingText(heading));
-      if (nextText) {
-        return nextText;
-      }
-    }
-  }
-  return undefined;
-}
-
-function getFollowingText(element: Element): string {
-  let node: Element | null = element.nextElementSibling;
-  while (node) {
-    const text = normalizeText(node.textContent);
-    if (text) {
-      return text;
-    }
-    node = node.nextElementSibling;
-  }
-  return "";
-}
-
-function extractDescription(main: Element | Document): string | undefined {
-  const container = main instanceof Document ? main.body : main;
-  if (!container) return undefined;
-
-  const candidates = Array.from(container.querySelectorAll("article, section, div"));
-  let bestText = "";
-  let bestScore = 0;
-  for (const candidate of candidates) {
-    const text = normalizeText(candidate.textContent);
-    if (text.length < 80) continue;
-    const className = candidate.getAttribute("class")?.toLowerCase() ?? "";
-    const dataSection = candidate.getAttribute("data-section")?.toLowerCase() ?? "";
-    let score = text.length;
-    if (/description|mission|detail|content|job-body|presentation/.test(className + dataSection)) {
-      score += 250;
-    }
-    if (candidate.querySelector("p")) {
-      score += 50;
-    }
-    if (score > bestScore) {
-      bestScore = score;
-      bestText = text;
-    }
-  }
-
-  if (!bestText) {
-    const fallback = normalizeText(container.textContent);
-    if (fallback.length >= 120) {
-      bestText = fallback;
-    }
-  }
-
-  if (!bestText) {
-    return undefined;
-  }
-
-  return bestText;
-}
-
-function buildCardSnippet(card: Element, title: string): string {
-  const text = normalizeText(card.textContent);
-  if (!text) return "";
-  const cleaned = text.replace(title, "").trim();
-  const snippet = cleaned.length > 0 ? cleaned : text;
-  return truncate(snippet, 320);
-}
-
-function splitSegments(text: string): string[] {
-  return text
-    .split(/\n|•|\||,|;|\u2022/) // bullet separators
-    .map((segment) => normalizeText(segment))
-    .filter((segment) => Boolean(segment));
-}
-
-function detectTechnologiesFromTexts(texts: string[], stack: Set<string>) {
-  for (const text of texts) {
-    if (!text) continue;
-    for (const tech of TECHNOLOGY_PATTERNS) {
-      if (tech.pattern.test(text)) {
-        stack.add(tech.label);
-      }
-    }
-  }
-}
-
-function computeConfidence(params: {
-  hasTitle: boolean;
-  hasRate: boolean;
-  hasLocationOrRemote: boolean;
-  stackCount: number;
-  descriptionLength: number;
-  hasContract: boolean;
-}): number {
-  let score = 0.25;
-  if (params.hasTitle) score += 0.2;
-  if (params.hasRate) score += 0.15;
-  if (params.hasLocationOrRemote) score += 0.15;
-  if (params.stackCount >= 2) score += 0.1;
-  else if (params.stackCount === 1) score += 0.05;
-  if (params.descriptionLength >= 180) score += 0.1;
-  else if (params.descriptionLength >= 60) score += 0.05;
-  if (params.hasContract) score += 0.05;
-  return Math.min(1, Math.max(0, score));
-}
-
-function pushEvidence(list: OfferEvidence[], label: string, snippet?: string, selector?: string) {
-  if (!snippet) return;
-  const normalized = truncate(snippet, 220);
-  list.push({ label, snippet: normalized, selector });
-}
-
-function buildSelector(element: Element): string {
-  const segments: string[] = [];
-  let current: Element | null = element;
-  while (current && segments.length < 4) {
-    let segment = current.tagName.toLowerCase();
-    if (current.id) {
-      segment += `#${current.id}`;
-      segments.unshift(segment);
-      break;
-    }
-    if (current.classList.length > 0) {
-      segment += `.${Array.from(current.classList).slice(0, 2).join('.')}`;
-    }
-    segments.unshift(segment);
-    current = current.parentElement;
-  }
-  return segments.join(" > ");
-}
-
-function looksLikeRate(text: string): boolean {
-  return /€|eur|\beuros?|\btjm/i.test(text) && /\d/.test(text);
-}
-
-function parseRate(rawText: string): NormalizedRate | undefined {
-  const raw = normalizeText(rawText);
-  if (!raw) return undefined;
-  const valueMatch = raw.match(/(\d+[\d\s,.]*)/);
-  const currency = /€/.test(raw)
-    ? "EUR"
-    : /\bchf\b/i.test(raw)
-      ? "CHF"
-      : /\busd\b|\$/.test(raw)
-        ? "USD"
-        : undefined;
-  const periodMatch = raw.match(/(jour|day|mois|month|an|year|semaine|week)/i);
-  const period = periodMatch
-    ? periodMatch[0].toLowerCase().startsWith("jour") || periodMatch[0].toLowerCase().startsWith("day")
-      ? "day"
-      : periodMatch[0].toLowerCase().startsWith("mois") || periodMatch[0].toLowerCase().startsWith("month")
-        ? "month"
-        : periodMatch[0].toLowerCase().startsWith("semaine") || periodMatch[0].toLowerCase().startsWith("week")
-          ? "week"
-          : "year"
-    : undefined;
-
-  let value: number | undefined;
-  if (valueMatch) {
-    const numeric = valueMatch[1].replace(/[\s,]/g, (char) => (char === "," ? "." : ""));
-    const parsed = Number.parseFloat(numeric);
-    if (!Number.isNaN(parsed)) {
-      value = Number(parsed.toFixed(2));
-    }
-  }
-
-  return {
-    raw,
-    value,
-    currency,
-    period,
-  };
-}
-
-function truncate(value: string, max = 800): string {
-  if (value.length <= max) {
-    return value;
-  }
-  return `${value.slice(0, max).trimEnd()}…`;
-}
-
-function uniqueStrings(values: string[]): string[] {
-  const set = new Set<string>();
-  for (const value of values) {
-    if (!value) continue;
-    set.add(value);
-  }
-  return Array.from(set);
-}
-
-function normalizeText(value: string | null | undefined): string {
-  return value ? value.replace(/\s+/g, " ").trim() : "";
 }
 
 function buildSuccessMessage(pageType: DetectionPageType, count: number): string {
@@ -865,33 +180,4 @@ function buildSuccessMessage(pageType: DetectionPageType, count: number): string
     return "Offre détectée (détail)";
   }
   return "Détection FreeWork";
-}
-
-function safeParseUrl(url: string): URL | null {
-  try {
-    return new URL(url);
-  } catch (error) {
-    return null;
-  }
-}
-
-function isFreeWorkDomain(url: URL): boolean {
-  return url.hostname.endsWith(FREEWORK_HOST_SUFFIX);
-}
-
-function toAbsoluteUrl(href: string, base: URL): string | null {
-  try {
-    return new URL(href, base).toString();
-  } catch (error) {
-    return null;
-  }
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function currentTime(options: DetectionOptions): number {
-  const nowProvider = options.now ?? (() => new Date());
-  return nowProvider().getTime();
 }

--- a/packages/detectors/src/freework/index.ts
+++ b/packages/detectors/src/freework/index.ts
@@ -1,0 +1,1 @@
+export * from "./detector";

--- a/packages/detectors/src/freework/list.ts
+++ b/packages/detectors/src/freework/list.ts
@@ -1,0 +1,171 @@
+import type { JobOffer } from "../types";
+import { normalizeText } from "../normalize/text";
+import { splitSegments, buildCardSnippet } from "../parsing/cards";
+import { collectMetaTexts } from "../parsing/meta";
+import { looksLikeRate, parseRate } from "../normalize/rate";
+import { findLocation } from "../normalize/location";
+import { detectRemote } from "../normalize/remote";
+import type { RemoteInfo } from "../normalize/remote";
+import { detectTechnologiesFromTexts } from "../parsing/technologies";
+import { collectTags } from "../parsing/tags";
+import { findContractType } from "../parsing/contract";
+import { computeConfidence } from "../state/confidence";
+import { populateEvidence } from "../state/evidence";
+import type { EvidenceParts } from "../state/evidence";
+import { uniqueStrings } from "../utils/collections";
+import { toAbsoluteUrl } from "../utils/url";
+
+interface CardCandidate {
+  root: Element;
+  anchor: HTMLAnchorElement;
+  title: string;
+}
+
+interface CardMetaData {
+  rateText?: string;
+  rate?: JobOffer["rate"];
+  location?: string;
+  remote: RemoteInfo;
+  contractType?: string;
+}
+
+/**
+ * Extrait chaque carte d'offre visible sur une page liste FreeWork. Les heuristiques
+ * de parsing sont mutualisées avec le mode détail pour limiter les divergences.
+ */
+export function extractListOffers(document: Document, pageUrl: URL): JobOffer[] {
+  const offers: JobOffer[] = [];
+  const cards = findOfferCards(document);
+
+  for (const card of cards) {
+    const offer = buildOfferFromCard(card, pageUrl);
+    if (offer) {
+      offers.push(offer);
+    }
+  }
+
+  return offers;
+}
+
+function findOfferCards(document: Document): CardCandidate[] {
+  const seen = new Set<Element>();
+  const cards: CardCandidate[] = [];
+  const anchors = Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href]"));
+
+  for (const anchor of anchors) {
+    const href = anchor.getAttribute("href");
+    if (!href || !/\bjob\b/i.test(href)) {
+      continue;
+    }
+
+    const titleElement = anchor.querySelector("h1, h2, h3, h4, h5") ?? anchor;
+    const title = normalizeText(titleElement.textContent);
+    if (!title || title.length < 5 || /postuler/i.test(title)) {
+      continue;
+    }
+
+    const root = anchor.closest("article, li, section, div") ?? anchor;
+    if (seen.has(root)) {
+      continue;
+    }
+
+    seen.add(root);
+    cards.push({ root, anchor, title });
+  }
+
+  return cards;
+}
+
+function buildOfferFromCard(card: CardCandidate, pageUrl: URL): JobOffer | null {
+  const absoluteUrl = toAbsoluteUrl(card.anchor.getAttribute("href") ?? "", pageUrl);
+  if (!absoluteUrl) {
+    return null;
+  }
+
+  const segments = collectCardSegments(card);
+  const meta = deriveMetaData(segments);
+  const tags = collectTags(card.root);
+  const stack = buildCardStack(card.title, segments, tags);
+  const snippet = buildCardSnippet(card.root, card.title);
+
+  const offer: JobOffer = {
+    source: "FreeWork",
+    url: absoluteUrl,
+    title: card.title,
+    location: meta.location,
+    isRemote: meta.remote.isRemote,
+    remotePolicy: meta.remote.policy,
+    contractType: meta.contractType,
+    rate: meta.rate,
+    stack,
+    description: snippet,
+    tags: uniqueStrings([...tags, ...stack]),
+    confidence: 0,
+    evidence: [],
+  };
+
+  applyCardConfidence(offer, stack.length, snippet.length, meta);
+  populateEvidence(offer, card.anchor, buildCardEvidence(meta, snippet, offer.tags));
+
+  return offer;
+}
+
+function collectCardSegments(card: CardCandidate): string[] {
+  const cardText = normalizeText(card.root.textContent);
+  const segments = splitSegments(cardText);
+  const metaCandidates = collectMetaTexts(card.root);
+  return uniqueStrings([...segments, ...metaCandidates]);
+}
+
+function deriveMetaData(segments: string[]): CardMetaData {
+  const rateText = segments.find(looksLikeRate);
+  const rate = rateText ? parseRate(rateText) : undefined;
+
+  let location = findLocation(segments, { includeRemote: true });
+  const remote = detectRemote(segments);
+  if (!location && remote.snippet) {
+    location = remote.snippet;
+  }
+
+  return {
+    rateText,
+    rate,
+    location,
+    remote,
+    contractType: findContractType(segments),
+  };
+}
+
+function buildCardStack(title: string, segments: string[], tags: string[]): string[] {
+  const stackSet = new Set<string>();
+  detectTechnologiesFromTexts([title, ...segments], stackSet);
+  tags.forEach((tag) => stackSet.add(tag));
+  return Array.from(stackSet);
+}
+
+function applyCardConfidence(
+  offer: JobOffer,
+  stackCount: number,
+  descriptionLength: number,
+  meta: CardMetaData,
+): void {
+  offer.confidence = computeConfidence({
+    hasTitle: Boolean(offer.title),
+    hasRate: Boolean(meta.rate),
+    hasLocationOrRemote: Boolean(meta.location || meta.remote.isRemote),
+    stackCount,
+    descriptionLength,
+    hasContract: Boolean(meta.contractType),
+  });
+}
+
+function buildCardEvidence(meta: CardMetaData, snippet: string, tags: string[]): EvidenceParts {
+  return {
+    rateText: meta.rateText,
+    location: meta.location,
+    contractType: meta.contractType,
+    descriptionSnippet: snippet,
+    remoteSnippet: meta.remote.snippet,
+    tags,
+  };
+}

--- a/packages/detectors/src/normalize/location.test.ts
+++ b/packages/detectors/src/normalize/location.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { findLocation } from "./location";
+
+const baseSegments = ["Paris 75009", "Freelance", "TJM 600 €"];
+
+describe("location detection", () => {
+  it("returns explicit city when present", () => {
+    expect(findLocation(baseSegments, { includeRemote: false })).toBe("Paris 75009");
+  });
+
+  it("ignores remote keyword when includeRemote false", () => {
+    const segments = ["Remote", "France"];
+    expect(findLocation(segments, { includeRemote: false })).toBe("France");
+  });
+
+  it("accepts remote snippets when includeRemote true", () => {
+    const segments = ["Full remote possible"];
+    expect(findLocation(segments, { includeRemote: true })).toBe("Full remote possible");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(findLocation(["Contrat freelance"], { includeRemote: true })).toBeUndefined();
+  });
+});

--- a/packages/detectors/src/normalize/location.ts
+++ b/packages/detectors/src/normalize/location.ts
@@ -1,0 +1,61 @@
+import { looksLikeRate } from "./rate";
+import { REMOTE_PATTERNS } from "./remote";
+
+const LOCATION_KEYWORDS = [
+  "paris",
+  "lyon",
+  "marseille",
+  "toulouse",
+  "bordeaux",
+  "nantes",
+  "lille",
+  "rennes",
+  "grenoble",
+  "strasbourg",
+  "montpellier",
+  "nice",
+  "sophia",
+  "niort",
+  "brest",
+  "dijon",
+  "tours",
+  "angers",
+  "rouen",
+  "saint",
+  "télétravail",
+  "remote",
+  "hybride",
+  "france",
+  "idf",
+];
+
+export function findLocation(metaTexts: string[], options: { includeRemote: boolean }): string | undefined {
+  for (const text of metaTexts) {
+    if (!text) continue;
+    if (!options.includeRemote && REMOTE_PATTERNS.some((pattern) => pattern.test(text))) {
+      continue;
+    }
+    if (looksLikeRate(text) || /dur[eé]e/i.test(text) || /d[eé]marrage/i.test(text) || /exp[eé]rience/i.test(text)) {
+      continue;
+    }
+    const lower = text.toLowerCase();
+    if (/freelance|cdi|cdd|stage|alternance|portage/.test(lower)) {
+      continue;
+    }
+    if (LOCATION_KEYWORDS.some((keyword) => lower.includes(keyword))) {
+      return text;
+    }
+    if (/\d{5}/.test(text) && /[A-Za-z]/.test(text)) {
+      return text;
+    }
+    const words = lower.split(/[,•-]/).map((part) => part.trim());
+    for (const word of words) {
+      if (word.length >= 3 && /^[a-zéèêàùâûç\s]+$/.test(word) && word.split(" ").length <= 3) {
+        if (!looksLikeRate(word) && !/exp[eé]rience|dur[eé]e|d[eé]marrage/.test(word)) {
+          return text;
+        }
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/detectors/src/normalize/rate.test.ts
+++ b/packages/detectors/src/normalize/rate.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeRate, parseRate } from "./rate";
+
+describe("rate normalization", () => {
+  it("detects textual rates", () => {
+    expect(looksLikeRate("TJM 600 € / jour")).toBe(true);
+    expect(looksLikeRate("Salaire compétitif")).toBe(false);
+  });
+
+  it("parses european daily rate", () => {
+    const rate = parseRate("TJM 600 € / jour");
+    expect(rate).toEqual({ raw: "TJM 600 € / jour", value: 600, currency: "EUR", period: "day" });
+  });
+
+  it("parses usd monthly rate", () => {
+    const rate = parseRate("Budget : 1 200 usd / month");
+    expect(rate).toEqual({ raw: "Budget : 1 200 usd / month", value: 1200, currency: "USD", period: "month" });
+  });
+
+  it("returns undefined when no numeric value", () => {
+    expect(parseRate("Tarif à négocier")).toBeUndefined();
+  });
+});

--- a/packages/detectors/src/normalize/rate.ts
+++ b/packages/detectors/src/normalize/rate.ts
@@ -1,0 +1,60 @@
+import type { NormalizedRate } from "../types";
+import { normalizeText } from "./text";
+
+const RATE_KEYWORDS = /(jour|day|mois|month|an|year|semaine|week|heure|hour)/i;
+const RATE_NUMERIC_PATTERN = /(\d+[\d\s,.]*)/;
+
+export function looksLikeRate(text: string): boolean {
+  return /€|eur|\beuros?|\btjm/i.test(text) && /\d/.test(text);
+}
+
+export function parseRate(rawText: string): NormalizedRate | undefined {
+  const raw = normalizeText(rawText);
+  if (!raw) return undefined;
+
+  const valueMatch = raw.match(RATE_NUMERIC_PATTERN);
+  if (!valueMatch) {
+    return undefined;
+  }
+  const periodMatch = raw.match(RATE_KEYWORDS);
+
+  let value: number | undefined;
+  if (valueMatch) {
+    const numeric = valueMatch[1].replace(/[\s,]/g, (char) => (char === "," ? "." : ""));
+    const parsed = Number.parseFloat(numeric);
+    if (!Number.isNaN(parsed)) {
+      value = Number(parsed.toFixed(2));
+    }
+  }
+
+  const currency = /€/.test(raw)
+    ? "EUR"
+    : /\bchf\b/i.test(raw)
+      ? "CHF"
+      : /\busd\b|\$/.test(raw)
+        ? "USD"
+        : undefined;
+
+  const period = periodMatch
+    ? normalizePeriod(periodMatch[0])
+    : undefined;
+
+  return { raw, value, currency, period };
+}
+
+function normalizePeriod(token: string): NormalizedRate["period"] {
+  const lowered = token.toLowerCase();
+  if (lowered.startsWith("jour") || lowered.startsWith("day")) {
+    return "day";
+  }
+  if (lowered.startsWith("mois") || lowered.startsWith("month")) {
+    return "month";
+  }
+  if (lowered.startsWith("semaine") || lowered.startsWith("week")) {
+    return "week";
+  }
+  if (lowered.includes("heure") || lowered.includes("hour")) {
+    return "hour";
+  }
+  return "year";
+}

--- a/packages/detectors/src/normalize/remote.test.ts
+++ b/packages/detectors/src/normalize/remote.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { detectRemote } from "./remote";
+
+describe("remote detection", () => {
+  it("identifies remote snippets", () => {
+    const result = detectRemote(["Mission en full remote"]);
+    expect(result.isRemote).toBe(true);
+    expect(result.policy).toBe("full-remote");
+    expect(result.snippet).toBe("Mission en full remote");
+  });
+
+  it("returns false when no indicators", () => {
+    expect(detectRemote(["Bureau à Paris"]).isRemote).toBe(false);
+  });
+});

--- a/packages/detectors/src/normalize/remote.ts
+++ b/packages/detectors/src/normalize/remote.ts
@@ -1,0 +1,40 @@
+export interface RemoteInfo {
+  isRemote: boolean;
+  snippet?: string;
+  policy?: string;
+}
+
+export const REMOTE_PATTERNS = [
+  /full\s*remote/i,
+  /remote/i,
+  /télétravail/i,
+  /teletravail/i,
+  /hybride/i,
+  /home\s*office/i,
+];
+
+export function detectRemote(texts: string[]): RemoteInfo {
+  for (const text of texts) {
+    if (!text) continue;
+    for (const pattern of REMOTE_PATTERNS) {
+      if (pattern.test(text)) {
+        return { isRemote: true, snippet: text, policy: normalizeRemotePolicy(text) };
+      }
+    }
+  }
+  return { isRemote: false };
+}
+
+export function normalizeRemotePolicy(text: string): string | undefined {
+  const normalized = text.toLowerCase();
+  if (normalized.includes("hybride")) {
+    return "hybrid";
+  }
+  if (normalized.includes("full")) {
+    return "full-remote";
+  }
+  if (normalized.includes("remote") || normalized.includes("télétravail") || normalized.includes("teletravail")) {
+    return "remote";
+  }
+  return undefined;
+}

--- a/packages/detectors/src/normalize/text.ts
+++ b/packages/detectors/src/normalize/text.ts
@@ -1,0 +1,16 @@
+/**
+ * Normalise une chaîne en supprimant les espaces superflus.
+ */
+export function normalizeText(value: string | null | undefined): string {
+  return value ? value.replace(/\s+/g, " ").trim() : "";
+}
+
+/**
+ * Tronque proprement une chaîne sans couper brutalement les mots.
+ */
+export function truncate(value: string, max = 800): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max).trimEnd()}…`;
+}

--- a/packages/detectors/src/parsing/cards.ts
+++ b/packages/detectors/src/parsing/cards.ts
@@ -1,0 +1,16 @@
+import { normalizeText, truncate } from "../normalize/text";
+
+export function splitSegments(text: string): string[] {
+  return text
+    .split(/\n|•|\||,|;|\u2022/)
+    .map((segment) => normalizeText(segment))
+    .filter((segment) => Boolean(segment));
+}
+
+export function buildCardSnippet(card: Element, title: string): string {
+  const text = normalizeText(card.textContent);
+  if (!text) return "";
+  const cleaned = text.replace(title, "").trim();
+  const snippet = cleaned.length > 0 ? cleaned : text;
+  return truncate(snippet, 320);
+}

--- a/packages/detectors/src/parsing/company.ts
+++ b/packages/detectors/src/parsing/company.ts
@@ -1,0 +1,28 @@
+import { normalizeText } from "../normalize/text";
+
+export function extractCompany(root: ParentNode): string | undefined {
+  const headings = Array.from(root.querySelectorAll("h2, h3, strong"));
+  for (const heading of headings) {
+    const text = normalizeText(heading.textContent);
+    if (!text) continue;
+    if (/soci[eé]t[eé]|entreprise|client/i.test(text)) {
+      const nextText = normalizeText(getFollowingText(heading));
+      if (nextText) {
+        return nextText;
+      }
+    }
+  }
+  return undefined;
+}
+
+function getFollowingText(element: Element): string {
+  let node: Element | null = element.nextElementSibling;
+  while (node) {
+    const text = normalizeText(node.textContent);
+    if (text) {
+      return text;
+    }
+    node = node.nextElementSibling;
+  }
+  return "";
+}

--- a/packages/detectors/src/parsing/contract.ts
+++ b/packages/detectors/src/parsing/contract.ts
@@ -1,0 +1,17 @@
+const CONTRACT_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /freelance/i, label: "Freelance" },
+  { pattern: /cdi/i, label: "CDI" },
+  { pattern: /cdd/i, label: "CDD" },
+  { pattern: /portage/i, label: "Portage" },
+  { pattern: /stage/i, label: "Stage" },
+  { pattern: /alternance/i, label: "Alternance" },
+];
+
+export function findContractType(metaTexts: string[]): string | undefined {
+  for (const { pattern, label } of CONTRACT_PATTERNS) {
+    if (metaTexts.some((text) => pattern.test(text))) {
+      return label;
+    }
+  }
+  return undefined;
+}

--- a/packages/detectors/src/parsing/description.ts
+++ b/packages/detectors/src/parsing/description.ts
@@ -1,0 +1,44 @@
+import { normalizeText, truncate } from "../normalize/text";
+
+export function extractDescription(main: Element | Document): string | undefined {
+  const container = main instanceof Document ? main.body : main;
+  if (!container) return undefined;
+
+  const candidates = Array.from(container.querySelectorAll("article, section, div"));
+  let bestText = "";
+  let bestScore = 0;
+
+  for (const candidate of candidates) {
+    const text = normalizeText(candidate.textContent);
+    if (text.length < 80) continue;
+
+    const className = candidate.getAttribute("class")?.toLowerCase() ?? "";
+    const dataSection = candidate.getAttribute("data-section")?.toLowerCase() ?? "";
+
+    let score = text.length;
+    if (/description|mission|detail|content|job-body|presentation/.test(className + dataSection)) {
+      score += 250;
+    }
+    if (candidate.querySelector("p")) {
+      score += 50;
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestText = text;
+    }
+  }
+
+  if (!bestText) {
+    const fallback = normalizeText(container.textContent);
+    if (fallback.length >= 120) {
+      bestText = fallback;
+    }
+  }
+
+  if (!bestText) {
+    return undefined;
+  }
+
+  return truncate(bestText, 900);
+}

--- a/packages/detectors/src/parsing/heading.ts
+++ b/packages/detectors/src/parsing/heading.ts
@@ -1,0 +1,4 @@
+export function findMainHeading(root: ParentNode): Element | null {
+  const heading = root.querySelector("h1") ?? root.querySelector("h2");
+  return heading;
+}

--- a/packages/detectors/src/parsing/meta.ts
+++ b/packages/detectors/src/parsing/meta.ts
@@ -1,0 +1,66 @@
+import { normalizeText } from "../normalize/text";
+
+export function collectMetaTexts(root: ParentNode): string[] {
+  const selectors = [".meta", "[class*='meta']", "[class*='info']", "header", "ul", "dl"];
+  const collected = new Set<string>();
+
+  for (const selector of selectors) {
+    const scope = root instanceof Document ? root : root;
+    const elements = scope.querySelectorAll(selector);
+    for (const element of elements) {
+      const nodes = element.querySelectorAll("span, div, li, dt, dd, p");
+      for (const child of Array.from(nodes)) {
+        const text = normalizeText(child.textContent);
+        if (!text || text.length > 140) continue;
+        collected.add(text);
+      }
+    }
+  }
+
+  if (root instanceof Element) {
+    const inlineCandidates = root.querySelectorAll("span, li, p");
+    for (const node of Array.from(inlineCandidates)) {
+      const text = normalizeText(node.textContent);
+      if (!text || text.length > 140) continue;
+      collected.add(text);
+    }
+  }
+
+  return Array.from(collected);
+}
+
+export function findByLabel(metaTexts: string[], label: RegExp): string | undefined {
+  for (const text of metaTexts) {
+    const match = text.match(label);
+    if (match) {
+      const parts = text.split(/[:-]/);
+      if (parts.length > 1) {
+        return normalizeText(parts.slice(1).join(":"));
+      }
+      const after = text.slice((match.index ?? 0) + match[0].length).trim();
+      if (after) {
+        return normalizeText(after);
+      }
+      return text;
+    }
+  }
+  return undefined;
+}
+
+export function findExperience(metaTexts: string[]): string | undefined {
+  for (const text of metaTexts) {
+    if (/exp[eé]rience/i.test(text) || /junior/i.test(text) || /senior/i.test(text) || /\b\d+\s*(ans|years)/i.test(text)) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+export function findPostedAt(metaTexts: string[]): string | undefined {
+  for (const text of metaTexts) {
+    if (/publi[eé]e?/i.test(text) || /post[eé]e?/i.test(text) || /il y a/i.test(text)) {
+      return text;
+    }
+  }
+  return undefined;
+}

--- a/packages/detectors/src/parsing/tags.ts
+++ b/packages/detectors/src/parsing/tags.ts
@@ -1,0 +1,36 @@
+import { normalizeText } from "../normalize/text";
+
+export function collectTags(root: ParentNode): string[] {
+  const selectors = [".tag", "[class*='tag']", "[class*='skill']", "[class*='stack']", "[data-tag]"];
+  const tags = new Set<string>();
+
+  for (const selector of selectors) {
+    const scope = root instanceof Document ? root : root;
+    const elements = scope.querySelectorAll(selector);
+    for (const element of elements) {
+      const text = normalizeText(element.textContent);
+      if (!text || text.length > 40) continue;
+
+      const className = element.getAttribute("class")?.toLowerCase() ?? "";
+      const classes = className.split(/\s+/);
+      if (classes.some((cls) => cls === "tags" || cls === "tags-list" || cls === "tag-list")) {
+        continue;
+      }
+
+      if (element.childElementCount > 0) {
+        const hasTagChild = Array.from(element.children).some((child) => {
+          const childClass = child.getAttribute("class")?.toLowerCase() ?? "";
+          return childClass.includes("tag");
+        });
+        if (hasTagChild) {
+          continue;
+        }
+      }
+
+      if (/^tag$/i.test(text)) continue;
+      tags.add(text);
+    }
+  }
+
+  return Array.from(tags);
+}

--- a/packages/detectors/src/parsing/technologies.ts
+++ b/packages/detectors/src/parsing/technologies.ts
@@ -1,0 +1,54 @@
+const TECHNOLOGY_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  { label: "Node.js", pattern: /node\.?js/i },
+  { label: "React", pattern: /react/i },
+  { label: "TypeScript", pattern: /typescript|ts\b/i },
+  { label: "JavaScript", pattern: /javascript/i },
+  { label: "AWS", pattern: /\baws\b/i },
+  { label: "Azure", pattern: /azure/i },
+  { label: "GCP", pattern: /\bgoogle cloud|\bgcp\b/i },
+  { label: "Kubernetes", pattern: /kubernetes|k8s/i },
+  { label: "Docker", pattern: /docker/i },
+  { label: "Terraform", pattern: /terraform/i },
+  { label: "Java", pattern: /\bjava\b/i },
+  { label: "Spring", pattern: /spring\b/i },
+  { label: "Python", pattern: /python/i },
+  { label: "Django", pattern: /django/i },
+  { label: "Flask", pattern: /flask/i },
+  { label: "PHP", pattern: /\bphp\b/i },
+  { label: "Symfony", pattern: /symfony/i },
+  { label: "Laravel", pattern: /laravel/i },
+  { label: "Go", pattern: /\bgo\b|golang/i },
+  { label: "Rust", pattern: /rust/i },
+  { label: "C#", pattern: /c#/i },
+  { label: "C++", pattern: /c\+\+/i },
+  { label: "Ruby", pattern: /ruby/i },
+  { label: "Rails", pattern: /rails/i },
+  { label: "Scala", pattern: /scala/i },
+  { label: "Swift", pattern: /swift/i },
+  { label: "Kotlin", pattern: /kotlin/i },
+  { label: "Android", pattern: /android/i },
+  { label: "iOS", pattern: /\bios\b/i },
+  { label: "Angular", pattern: /angular/i },
+  { label: "Vue", pattern: /vue\.js|vuejs|\bvue\b/i },
+  { label: "Svelte", pattern: /svelte/i },
+  { label: "GraphQL", pattern: /graphql/i },
+  { label: "PostgreSQL", pattern: /postgresql|postgres/i },
+  { label: "MySQL", pattern: /mysql/i },
+  { label: "MongoDB", pattern: /mongodb/i },
+  { label: "Redis", pattern: /redis/i },
+  { label: "Kafka", pattern: /kafka/i },
+  { label: "Spark", pattern: /spark/i },
+  { label: "Hadoop", pattern: /hadoop/i },
+  { label: "Elasticsearch", pattern: /elasticsearch|elastic/i },
+];
+
+export function detectTechnologiesFromTexts(texts: string[], stack: Set<string>): void {
+  for (const text of texts) {
+    if (!text) continue;
+    for (const tech of TECHNOLOGY_PATTERNS) {
+      if (tech.pattern.test(text)) {
+        stack.add(tech.label);
+      }
+    }
+  }
+}

--- a/packages/detectors/src/state/confidence.ts
+++ b/packages/detectors/src/state/confidence.ts
@@ -1,0 +1,21 @@
+export interface ConfidenceInputs {
+  hasTitle: boolean;
+  hasRate: boolean;
+  hasLocationOrRemote: boolean;
+  stackCount: number;
+  descriptionLength: number;
+  hasContract: boolean;
+}
+
+export function computeConfidence(params: ConfidenceInputs): number {
+  let score = 0.25;
+  if (params.hasTitle) score += 0.2;
+  if (params.hasRate) score += 0.15;
+  if (params.hasLocationOrRemote) score += 0.15;
+  if (params.stackCount >= 2) score += 0.1;
+  else if (params.stackCount === 1) score += 0.05;
+  if (params.descriptionLength >= 180) score += 0.1;
+  else if (params.descriptionLength >= 60) score += 0.05;
+  if (params.hasContract) score += 0.05;
+  return Math.min(1, Math.max(0, score));
+}

--- a/packages/detectors/src/state/evidence.ts
+++ b/packages/detectors/src/state/evidence.ts
@@ -1,0 +1,76 @@
+import type { JobOffer, OfferEvidence } from "../types";
+import { truncate } from "../normalize/text";
+import { buildSelector } from "../utils/selectors";
+
+export interface EvidenceParts {
+  rateText?: string;
+  location?: string;
+  contractType?: string;
+  startDate?: string;
+  duration?: string;
+  experienceLevel?: string;
+  postedAt?: string;
+  remoteSnippet?: string;
+  descriptionSnippet?: string;
+  tags?: string[];
+}
+
+export function populateEvidence(
+  offer: JobOffer,
+  titleElement: Element | null,
+  parts: EvidenceParts,
+): void {
+  const evidence: OfferEvidence[] = [];
+  pushEvidence(evidence, "title", offer.title, titleElement ? buildSelector(titleElement) : undefined);
+  if (parts.rateText) {
+    pushEvidence(evidence, "rate", parts.rateText);
+  }
+  if (parts.location) {
+    pushEvidence(evidence, "location", parts.location);
+  }
+  if (offer.rate?.raw && !parts.rateText) {
+    pushEvidence(evidence, "rate", offer.rate.raw);
+  }
+  if (parts.contractType) {
+    pushEvidence(evidence, "contract", parts.contractType);
+  }
+  if (parts.startDate) {
+    pushEvidence(evidence, "startDate", parts.startDate);
+  }
+  if (parts.duration) {
+    pushEvidence(evidence, "duration", parts.duration);
+  }
+  if (parts.experienceLevel) {
+    pushEvidence(evidence, "experience", parts.experienceLevel);
+  }
+  if (parts.postedAt) {
+    pushEvidence(evidence, "postedAt", parts.postedAt);
+  }
+  if (parts.remoteSnippet) {
+    pushEvidence(evidence, "remote", parts.remoteSnippet);
+  }
+  if (parts.descriptionSnippet) {
+    pushEvidence(evidence, "description", truncate(parts.descriptionSnippet, 180));
+  }
+  if (parts.tags && parts.tags.length > 0) {
+    pushEvidence(evidence, "tags", parts.tags.slice(0, 3).join(", "));
+  }
+
+  if (evidence.length < 3 && offer.description) {
+    pushEvidence(evidence, "context", truncate(offer.description, 160));
+  }
+  if (evidence.length < 3 && offer.rate?.raw) {
+    pushEvidence(evidence, "pricing", offer.rate.raw);
+  }
+  if (evidence.length < 3 && offer.location) {
+    pushEvidence(evidence, "geo", offer.location);
+  }
+
+  offer.evidence = evidence;
+}
+
+function pushEvidence(list: OfferEvidence[], label: string, snippet?: string, selector?: string): void {
+  if (!snippet) return;
+  const normalized = truncate(snippet, 220);
+  list.push({ label, snippet: normalized, selector });
+}

--- a/packages/detectors/src/state/poller.ts
+++ b/packages/detectors/src/state/poller.ts
@@ -1,0 +1,47 @@
+import type { DetectionOptions } from "../types";
+import { delay, timestamp } from "../utils/time";
+
+export interface PollOutcome<T> {
+  value: T;
+  attempts: number;
+  waitedMs: number;
+}
+
+interface PollConfig {
+  maxWaitMs: number;
+  pollIntervalMs: number;
+}
+
+export async function pollUntil<T>(
+  options: DetectionOptions,
+  config: PollConfig,
+  check: () => T,
+  isReady: (value: T) => boolean,
+): Promise<PollOutcome<T>> {
+  const start = timestamp(options);
+  const deadline = start + config.maxWaitMs;
+
+  let attempts = 1;
+  let value = check();
+  if (isReady(value)) {
+    const waited = Math.max(0, timestamp(options) - start);
+    return { value, attempts, waitedMs: waited };
+  }
+
+  for (let now = start; now < deadline; now = timestamp(options)) {
+    const remaining = Math.max(0, deadline - now);
+    const waitDuration = Math.min(config.pollIntervalMs, remaining);
+    if (waitDuration > 0) {
+      await delay(waitDuration);
+    }
+    attempts += 1;
+    value = check();
+    if (isReady(value)) {
+      const waited = Math.max(0, timestamp(options) - start);
+      return { value, attempts, waitedMs: waited };
+    }
+  }
+
+  const waitedMs = Math.max(0, timestamp(options) - start);
+  return { value, attempts, waitedMs };
+}

--- a/packages/detectors/src/types/index.ts
+++ b/packages/detectors/src/types/index.ts
@@ -1,0 +1,11 @@
+export type {
+  DetectionDiagnostics,
+  DetectionOptions,
+  DetectionPageType,
+  JobOffer,
+  NormalizedRate,
+  OfferDetectionItem,
+  OfferDetectionOutcome,
+  OfferDetectionResult,
+  OfferEvidence,
+} from "@freelancefinder/types";

--- a/packages/detectors/src/utils/collections.ts
+++ b/packages/detectors/src/utils/collections.ts
@@ -1,0 +1,8 @@
+export function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  const set = new Set<string>();
+  for (const value of values) {
+    if (!value) continue;
+    set.add(value);
+  }
+  return Array.from(set);
+}

--- a/packages/detectors/src/utils/selectors.ts
+++ b/packages/detectors/src/utils/selectors.ts
@@ -1,0 +1,18 @@
+export function buildSelector(element: Element): string {
+  const segments: string[] = [];
+  let current: Element | null = element;
+  while (current && segments.length < 4) {
+    let segment = current.tagName.toLowerCase();
+    if (current.id) {
+      segment += `#${current.id}`;
+      segments.unshift(segment);
+      break;
+    }
+    if (current.classList.length > 0) {
+      segment += `.${Array.from(current.classList).slice(0, 2).join('.')}`;
+    }
+    segments.unshift(segment);
+    current = current.parentElement;
+  }
+  return segments.join(" > ");
+}

--- a/packages/detectors/src/utils/time.ts
+++ b/packages/detectors/src/utils/time.ts
@@ -1,0 +1,10 @@
+import type { DetectionOptions } from "../types";
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function timestamp(options: DetectionOptions): number {
+  const nowProvider = options.now ?? (() => new Date());
+  return nowProvider().getTime();
+}

--- a/packages/detectors/src/utils/url.ts
+++ b/packages/detectors/src/utils/url.ts
@@ -1,0 +1,21 @@
+const FREEWORK_HOST_SUFFIX = "free-work.com";
+
+export function safeParseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch (error) {
+    return null;
+  }
+}
+
+export function isFreeWorkDomain(url: URL): boolean {
+  return url.hostname.endsWith(FREEWORK_HOST_SUFFIX);
+}
+
+export function toAbsoluteUrl(href: string, base: URL): string | null {
+  try {
+    return new URL(href, base).toString();
+  } catch (error) {
+    return null;
+  }
+}

--- a/packages/types/src/offers.ts
+++ b/packages/types/src/offers.ts
@@ -13,7 +13,7 @@ export interface OfferEvidence {
   selector?: string;
 }
 
-export interface OfferDetectionItem {
+export interface JobOffer {
   source: "FreeWork" | string;
   url: string;
   title?: string;
@@ -34,6 +34,8 @@ export interface OfferDetectionItem {
   evidence: OfferEvidence[];
 }
 
+export type OfferDetectionItem = JobOffer;
+
 export type DetectionPageType = "detail" | "list" | "unknown";
 
 export interface DetectionOptions {
@@ -43,14 +45,18 @@ export interface DetectionOptions {
   now?: () => Date;
 }
 
-export interface OfferDetectionOutcome {
+export interface DetectionDiagnostics {
+  waitedMs?: number;
+  attempts?: number;
+  reason?: string;
+}
+
+export interface OfferDetectionResult {
   status: "ok" | "out_of_scope" | "no_offers" | "content_delayed";
   message: string;
   pageType: DetectionPageType;
-  offers: OfferDetectionItem[];
-  diagnostics?: {
-    waitedMs?: number;
-    attempts?: number;
-    reason?: string;
-  };
+  offers: JobOffer[];
+  diagnostics?: DetectionDiagnostics;
 }
+
+export type OfferDetectionOutcome = OfferDetectionResult;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,31 @@ importers:
         specifier: ^1.5.0
         version: 1.6.1(@types/node@20.19.15)(jsdom@24.1.3)
 
+  apps/extension-demo:
+    dependencies:
+      '@freelancefinder/detectors':
+        specifier: workspace:*
+        version: link:../../packages/detectors
+      '@freelancefinder/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+    devDependencies:
+      '@freelancefinder/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@types/chrome':
+        specifier: ^0.0.255
+        version: 0.0.255
+      esbuild-plugin-alias:
+        specifier: ^0.2.1
+        version: 0.2.1
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(tsx@4.20.5)(typescript@5.9.2)
+      vitest:
+        specifier: ^1.5.0
+        version: 1.6.1
+
   apps/web:
     dependencies:
       next:
@@ -1025,8 +1050,29 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@types/chrome@0.0.255:
+    resolution: {integrity: sha512-w0ZDbbkecWN8GZYkjI1WhqOzxVzxXgepDvWu3egYy5NNK74wfEPN9lS1ui8AZCCJZdHEO9dv9Xbv2BdDiKlSNw==}
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+    dev: true
+
   /@types/estree@1.0.8:
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+    dev: true
+
+  /@types/filesystem@0.0.36:
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+    dependencies:
+      '@types/filewriter': 0.0.33
+    dev: true
+
+  /@types/filewriter@0.0.33:
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+    dev: true
+
+  /@types/har-format@1.2.16:
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
     dev: true
 
   /@types/jsdom@21.1.7:
@@ -1639,6 +1685,10 @@ packages:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+    dev: true
+
+  /esbuild-plugin-alias@0.2.1:
+    resolution: {integrity: sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==}
     dev: true
 
   /esbuild@0.21.5:
@@ -3493,6 +3543,62 @@ packages:
       rollup: 4.50.2
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@20.19.15)
+      vite-node: 1.6.1(@types/node@20.19.15)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vitest@1.6.1(@types/node@20.19.15)(jsdom@24.1.3):


### PR DESCRIPTION
## Summary
- split FreeWork detection into reusable normalize/parsing/state/utils modules and expose a unified JobOffer contract
- update the extension demo to TypeScript with modular popup/content script orchestration and a resilient detector loader with tests
- introduce shared bundling/linting config for the extension and document the refactor plan in REFACTORING.md

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd3f1c06c832d97bd673dd26e1e18